### PR TITLE
[UPD] ssi_web_x2m_search

### DIFF
--- a/ssi_web_x2m_search/README.rst
+++ b/ssi_web_x2m_search/README.rst
@@ -9,6 +9,9 @@ Web X2Many Search
 Adds the standard Odoo **search bar** inside every One2many and Many2many field
 rendered as a list in a form view.
 
+The search bar occupies its own full-width row, above the field's
+``Add a line`` button and pager.
+
 Typing in the search bar opens the usual autocompletion dropdown (*Search Name
 for: budi*), and validating it creates a search facet, exactly like the search
 bar of a regular list view. Several facets can be combined, and each facet can

--- a/ssi_web_x2m_search/static/src/scss/x2m_search.scss
+++ b/ssi_web_x2m_search/static/src/scss/x2m_search.scss
@@ -7,21 +7,14 @@
 .o_x2m_control_panel {
     .o_x2m_search {
         display: flex;
-        flex: 0 1 auto;
+        flex: 1 1 100%; // force a full row of its own
+        order: -1; // first row, above the buttons + pager
         align-items: center;
         min-width: 0;
-        margin: 5px 8px 0;
+        margin: 5px 0 0;
 
         .o_searchview_input_container {
             flex-wrap: wrap;
-        }
-    }
-
-    @include media-breakpoint-down(sm) {
-        .o_x2m_search {
-            flex: 1 1 100%;
-            margin: 5px 0 0;
-            order: 1;
         }
     }
 }


### PR DESCRIPTION
## Ringkasan

Search bar `ssi_web_x2m_search` kini selebar penuh field x2m, menempati barisnya sendiri di atas tombol `Add a line` dan pager, di semua ukuran layar (desktop & mobile).

* `static/src/scss/x2m_search.scss`: `.o_x2m_search` diubah menjadi `flex: 1 1 100%` dengan `order: -1`, memaksanya ke baris tersendiri di atas kontrol lain. Blok `media-breakpoint-down(sm)` lama dihapus karena jadi redundan (perilaku desktop & mobile kini identik).
* `README.rst`: deskripsi diperbarui untuk mencerminkan layout baru.

Referensi backlog: BL-0179.

## Test plan

- [x] `pre-commit run --all-files` lolos.
- [ ] Verifikasi visual (posisi search bar, dropdown autocomplete, dan pager) — dilakukan oleh reviewer/user, tidak dijalankan lokal pada sesi ini.