### PR TITLE
[UPD] ssi_web_x2m_search

### DIFF
--- a/ssi_web_x2m_search/static/src/scss/x2m_search.scss
+++ b/ssi_web_x2m_search/static/src/scss/x2m_search.scss
@@ -14,6 +14,11 @@
         margin: 5px 0 0;
 
         .o_searchview_input_container {
+            // Core only grows the input inside this container
+            // (search_view.scss: `.o_searchview_input { flex: 1 0 auto; width: 75px; }`),
+            // so the container itself must grow too, or the input stops at 75px
+            // and the rest of the full-width row stays dead space.
+            flex: 1 1 auto;
             flex-wrap: wrap;
         }
     }


### PR DESCRIPTION
Melebarkan input pencarian x2m mengikuti lebar barisnya.

BL-0179 sudah membuat baris `.o_x2m_search` selebar penuh (`flex: 1 1 100%` + `order: -1`), tapi anak di dalamnya — `.o_searchview_input_container` — tidak pernah diberi `flex-grow`, sehingga menyusut ke lebar kontennya (~75px). Core Odoo hanya menumbuhkan input **di dalam** kontainer itu (`search_view.scss`: `.o_searchview_input { flex: 1 0 auto; width: 75px; }`), jadi bila kontainernya sendiri tidak tumbuh, input berhenti di 75px dan sisa barisnya jadi ruang mati.

Perbaikan: menambahkan `flex: 1 1 auto;` pada `.o_searchview_input_container` (satu baris SCSS). `flex-wrap: wrap` dipertahankan agar facet tetap membungkus rapi, dan aturan BL-0179 tidak diubah.

Terverifikasi live via injeksi CSS di browser: lebar kontainer & input menjadi 1074px, sama dengan lebar baris (sebelumnya 75px).

Backlog: BL-0180