### PR TITLE
[UPD] ssi_web_gantt

### DIFF
--- a/ssi_web_gantt/README.rst
+++ b/ssi_web_gantt/README.rst
@@ -103,8 +103,24 @@ Presentation
 +-------------------------+----------+---------------------------------+-----------------------------------------------+
 | ``default_zoom``        | no       | ``1``                           | Column width multiplier, clamped to 0.5 - 4   |
 +-------------------------+----------+---------------------------------+-----------------------------------------------+
-| ``event_open_popup``    | no       |                                 | Form view id; clicking a bar opens a dialog   |
+| ``event_open_popup``    | no       | ``0``                           | Clicking a bar opens a dialog instead of      |
+|                         |          |                                 | switching to the form view                    |
 +-------------------------+----------+---------------------------------+-----------------------------------------------+
+| ``form_view_id``        | no       | the default form view           | XML id of the form view the dialog shows      |
++-------------------------+----------+---------------------------------+-----------------------------------------------+
+
+``form_view_id`` is only read when ``event_open_popup`` is enabled, and setting
+one without the other is refused when the view is saved. It is written as an XML
+id, because the database id of a view is not knowable when a module ships it:
+
+.. code-block:: xml
+
+    <ssi_gantt date_start="date_assign" date_stop="date_end"
+               event_open_popup="1" form_view_id="project.view_task_form2"/>
+
+The view it names has to exist, be a form view, and be a form view of the model
+the Gantt view is on; a view that is none of these is refused when the view is
+saved rather than silently opening the wrong form.
 
 The supported decorations are ``decoration-danger``, ``decoration-warning``,
 ``decoration-info``, ``decoration-success``, ``decoration-primary``,

--- a/ssi_web_gantt/models/ir_ui_view.py
+++ b/ssi_web_gantt/models/ir_ui_view.py
@@ -21,6 +21,18 @@ FIELD_ATTRIBUTES = [
     "dependency_field",
 ]
 
+# Falsy spellings of a boolean arch attribute. Kept in step with ``toBool`` in
+# static/src/js/gantt_view.js: the server and the browser have to agree on what
+# event_open_popup="0" means.
+FALSY_ATTRIBUTE_VALUES = ["", "0", "false", "False"]
+
+
+def is_truthy(value):
+    """Read a boolean arch attribute, which reaches us as a string or as None."""
+    if value is None:
+        return False
+    return value not in FALSY_ATTRIBUTE_VALUES
+
 
 class IrUiView(models.Model):
     _inherit = "ir.ui.view"
@@ -43,6 +55,11 @@ class IrUiView(models.Model):
 
         if name_manager.validate:
             self._validate_ssi_gantt_dates(node)
+            self._validate_ssi_gantt_form_view(node, name_manager.Model)
+
+        # Outside the validate branch on purpose: the JavaScript side needs the
+        # resolved id every time the arch is read, not only when it is checked.
+        self._resolve_ssi_gantt_form_view(node)
 
         node_info["editable"] = False
 
@@ -70,3 +87,81 @@ Solution: Add either date_stop or date_delay to the ssi_gantt tag
                 % (self.id,)
             )
             self.handle_view_error(error_message)
+
+    def _find_ssi_gantt_form_view(self, value):
+        """Resolve the form_view_id attribute, given either as an XML id or as a
+        database id, into an ir.ui.view record. Returns an empty recordset when
+        the value points at nothing."""
+        if value.isdigit():
+            return self.browse(int(value)).exists()
+        return self.env.ref(value, raise_if_not_found=False) or self.browse()
+
+    def _validate_ssi_gantt_form_view(self, node, model):
+        value = node.get("form_view_id")
+        if not value:
+            return
+
+        # A form view is only ever opened from the popup, so naming one without
+        # asking for the popup is a mistake the user has to be told about: the
+        # attribute would otherwise be read by nothing at all.
+        if not is_truthy(node.get("event_open_popup")):
+            error_message = _(
+                """
+Context: Validate ssi_gantt view architecture
+Database ID: %s
+Problem: Attribute form_view_id is set while event_open_popup is not enabled
+Solution: Add event_open_popup="1" to the ssi_gantt tag, or remove form_view_id
+"""
+                % (self.id,)
+            )
+            self.handle_view_error(error_message)
+
+        form_view = self._find_ssi_gantt_form_view(value)
+
+        if not form_view:
+            error_message = _(
+                """
+Context: Validate ssi_gantt view architecture
+Database ID: %s
+Problem: Attribute form_view_id %s does not point to any view
+Solution: Set form_view_id to the XML id of an existing form view of model %s
+"""
+                % (self.id, value, model._name)
+            )
+            self.handle_view_error(error_message)
+
+        if form_view.type != "form":
+            error_message = _(
+                """
+Context: Validate ssi_gantt view architecture
+Database ID: %s
+Problem: Attribute form_view_id %s points to a %s view, not to a form view
+Solution: Set form_view_id to the XML id of a form view of model %s
+"""
+                % (self.id, value, form_view.type, model._name)
+            )
+            self.handle_view_error(error_message)
+
+        if form_view.model != model._name:
+            error_message = _(
+                """
+Context: Validate ssi_gantt view architecture
+Database ID: %s
+Problem: Attribute form_view_id %s points to a form view of model %s
+Solution: Set form_view_id to the XML id of a form view of model %s
+"""
+                % (self.id, value, form_view.model, model._name)
+            )
+            self.handle_view_error(error_message)
+
+    def _resolve_ssi_gantt_form_view(self, node):
+        """Rewrite form_view_id into a database id. The attribute is written as
+        an XML id, because a database id cannot be known when a module ships the
+        view, but the JavaScript side can only feed a number to FormViewDialog."""
+        value = node.get("form_view_id")
+        if not value or value.isdigit():
+            return
+
+        form_view = self._find_ssi_gantt_form_view(value)
+        if form_view:
+            node.set("form_view_id", str(form_view.id))

--- a/ssi_web_gantt/static/src/js/gantt_controller.js
+++ b/ssi_web_gantt/static/src/js/gantt_controller.js
@@ -32,7 +32,8 @@ odoo.define("ssi_web_gantt.GanttController", function (require) {
             this.zoom = params.defaultZoom;
             this.scales = params.scales;
             this.scaleLabels = params.scaleLabels;
-            this.openPopupAction = params.openPopupAction;
+            this.openPopup = params.openPopup;
+            this.formViewId = params.formViewId;
             this.actionContext = params.actionContext;
         },
 
@@ -158,12 +159,14 @@ odoo.define("ssi_web_gantt.GanttController", function (require) {
         _onOpenRecord: function (event) {
             event.stopPropagation();
             const resId = event.data.id;
-            if (this.openPopupAction) {
+            if (this.openPopup) {
                 new dialogs.FormViewDialog(this, {
                     res_model: this.modelName,
                     res_id: resId,
                     context: this.actionContext,
-                    view_id: Number(this.openPopupAction),
+                    // False makes FormViewDialog fall back to the default form
+                    // view of the model.
+                    view_id: this.formViewId || false,
                     readonly: !this.model.rights.write,
                     on_saved: () => this.reload(),
                 }).open();

--- a/ssi_web_gantt/static/src/js/gantt_view.js
+++ b/ssi_web_gantt/static/src/js/gantt_view.js
@@ -104,7 +104,12 @@ odoo.define("ssi_web_gantt.GanttView", function (require) {
             this.controllerParams.defaultZoom = defaultZoom;
             this.controllerParams.scales = scales;
             this.controllerParams.scaleLabels = SCALE_LABELS;
-            this.controllerParams.openPopupAction = attrs.event_open_popup;
+            this.controllerParams.openPopup = toBool(attrs.event_open_popup, false);
+            // The server rewrites form_view_id from an XML id into a database
+            // id, so a number is all that can arrive here. An unresolvable id
+            // falls back to the default form view rather than to view id NaN.
+            this.controllerParams.formViewId =
+                parseInt(attrs.form_view_id, 10) || false;
             this.controllerParams.actionContext = params.action
                 ? params.action.context
                 : {};

--- a/ssi_web_gantt/tests/test_data_ssi_web_gantt.yaml
+++ b/ssi_web_gantt/tests/test_data_ssi_web_gantt.yaml
@@ -246,3 +246,131 @@ scenarios:
           view_id.type:
             type: "value"
             expected: "ssi_gantt"
+
+  - name: "ssi_web_gantt - event_open_popup is a boolean"
+    steps:
+      - step: "Create a view asking for the popup without naming a form view"
+        action: "create"
+        model: "ir.ui.view"
+        save_as: "view"
+        values:
+          name: "Partner SSI Gantt Popup Default Form"
+          model: "res.partner"
+          type: "ssi_gantt"
+          arch: |
+            <ssi_gantt
+                date_start="create_date"
+                date_stop="write_date"
+                event_open_popup="1"
+            />
+      - step: "Assert the arch was accepted"
+        action: "assert"
+        target: "view"
+        asserts:
+          type:
+            type: "value"
+            expected: "ssi_gantt"
+
+  - name: "ssi_web_gantt - form_view_id accepts an XML id"
+    steps:
+      - step: "Create a view naming a form view of its own model"
+        action: "create"
+        model: "ir.ui.view"
+        save_as: "view"
+        values:
+          name: "Partner SSI Gantt Popup Custom Form"
+          model: "res.partner"
+          type: "ssi_gantt"
+          arch: |
+            <ssi_gantt
+                date_start="create_date"
+                date_stop="write_date"
+                event_open_popup="1"
+                form_view_id="base.view_partner_form"
+            />
+      - step: "Assert the arch was accepted"
+        action: "assert"
+        target: "view"
+        asserts:
+          type:
+            type: "value"
+            expected: "ssi_gantt"
+
+  - name: "ssi_web_gantt - form_view_id pointing nowhere is rejected"
+    steps:
+      - step: "Create a view whose form_view_id XML id does not exist"
+        action: "create"
+        model: "ir.ui.view"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "form_view_id"
+        values:
+          name: "Partner SSI Gantt Popup Missing Form"
+          model: "res.partner"
+          type: "ssi_gantt"
+          arch: |
+            <ssi_gantt
+                date_start="create_date"
+                date_stop="write_date"
+                event_open_popup="1"
+                form_view_id="base.no_such_view_at_all"
+            />
+
+  - name: "ssi_web_gantt - form_view_id of a non form view is rejected"
+    steps:
+      - step: "Create a view whose form_view_id points to a tree view"
+        action: "create"
+        model: "ir.ui.view"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "form_view_id"
+        values:
+          name: "Partner SSI Gantt Popup Tree View"
+          model: "res.partner"
+          type: "ssi_gantt"
+          arch: |
+            <ssi_gantt
+                date_start="create_date"
+                date_stop="write_date"
+                event_open_popup="1"
+                form_view_id="base.view_partner_tree"
+            />
+
+  - name: "ssi_web_gantt - form_view_id of another model is rejected"
+    steps:
+      - step: "Create a res.partner view naming a res.users form view"
+        action: "create"
+        model: "ir.ui.view"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "form_view_id"
+        values:
+          name: "Partner SSI Gantt Popup Foreign Form"
+          model: "res.partner"
+          type: "ssi_gantt"
+          arch: |
+            <ssi_gantt
+                date_start="create_date"
+                date_stop="write_date"
+                event_open_popup="1"
+                form_view_id="base.view_users_form"
+            />
+
+  - name: "ssi_web_gantt - form_view_id without event_open_popup is rejected"
+    steps:
+      - step: "Create a view naming a form view but not asking for the popup"
+        action: "create"
+        model: "ir.ui.view"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "event_open_popup"
+        values:
+          name: "Partner SSI Gantt Form Without Popup"
+          model: "res.partner"
+          type: "ssi_gantt"
+          arch: |
+            <ssi_gantt
+                date_start="create_date"
+                date_stop="write_date"
+                form_view_id="base.view_partner_form"
+            />

--- a/ssi_web_gantt/tests/test_ssi_web_gantt.py
+++ b/ssi_web_gantt/tests/test_ssi_web_gantt.py
@@ -11,3 +11,28 @@ from odoo.tests import tagged
 class TestSsiWebGantt(YamlTransactionCase):
     def test_ssi_web_gantt(self):
         self.run_yaml_scenario("test_data_ssi_web_gantt.yaml")
+
+    def test_form_view_id_resolved_to_numeric_id(self):
+        # Written in Python rather than in the YAML scenario because the
+        # resolution is only observable in the return value of fields_view_get,
+        # and a YAML step can only assert fields on a record.
+        form_view = self.env.ref("base.view_partner_form")
+        view = self.env["ir.ui.view"].create(
+            {
+                "name": "Partner SSI Gantt Resolved Form View",
+                "model": "res.partner",
+                "type": "ssi_gantt",
+                "arch": """
+                <ssi_gantt
+                    date_start="create_date"
+                    date_stop="write_date"
+                    event_open_popup="1"
+                    form_view_id="base.view_partner_form"
+                />
+                """,
+            }
+        )
+        result = self.env["res.partner"].fields_view_get(
+            view_id=view.id, view_type="ssi_gantt"
+        )
+        self.assertIn('form_view_id="%s"' % form_view.id, result["arch"])


### PR DESCRIPTION
## Konteks

Ditemukan saat verifikasi manual `ssi_web_gantt` memakai `project.task` + `task.dependency` (repo `opnsynid-project`). Seluruh fitur lain lolos verifikasi (bar, 5 skala, zoom, today line, `color`, `decoration-*`, group by, panah dependensi FS/SS/FF/SF, konversi timezone, klik bar → form view). Hanya `event_open_popup` yang cacat.

## Masalah

`event_open_popup` **bukan boolean**, melainkan ID form view numerik:

```js
view_id: Number(this.openPopupAction),   // gantt_controller.js
```

Namanya meniru idiom `web_calendar` (di sana boolean), sehingga `event_open_popup="1"` — hal paling wajar untuk ditulis — membuka `ir.ui.view` **id 1**, sebuah form yang sama sekali tak berhubungan, **tanpa error apa pun**. Nilai non-numerik menghasilkan `view_id: NaN`, juga senyap.

Selain itu atribut ini praktis **tak terpakai dari XML modul**: ID numerik `ir.ui.view` berbeda di tiap database, jadi tidak ada cara sah menuliskan nilainya di data file.

## Perubahan

* `event_open_popup` kini **boolean** (memakai helper `toBool` yang sudah ada).
* Atribut baru **`form_view_id`** menentukan form view yang dibuka dialog. Ditulis sebagai **XML ID**; server me-resolve-nya menjadi ID numerik saat arch dibaca, sehingga sisi JS cukup menerima angka. Bila kosong → dialog memakai form view default model.
* **Validasi arch** (`ValidationError` saat view disimpan, bukan gagal senyap saat bar diklik): `form_view_id` yang tidak menunjuk view mana pun, menunjuk view bukan `form`, menunjuk form view model lain, atau diisi tanpa `event_open_popup`.
* `README.rst` diperbarui + contoh XML.

```xml
<ssi_gantt date_start="date_assign" date_stop="date_end"
           event_open_popup="1" form_view_id="project.view_task_form2"/>
```

## Test

6 skenario YAML baru (2 positif, 4 negative path via `expect_error`) + 1 test method Python (`test_form_view_id_resolved_to_numeric_id` — ditulis di Python karena resolusi XML ID → ID numerik hanya terlihat di nilai kembalian `fields_view_get`, sedangkan step YAML hanya bisa meng-assert field pada record).

## Catatan

Ini **breaking change** pada arch, karena itu `/ocabot merge major`. Aman: modul baru dan belum ada view `ssi_gantt` yang memakai `event_open_popup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)