### PR TITLE
[UPD] ssi_web_inbox: menu Discuss membuka client action inbox gaya Gmail

### DIFF
--- a/ssi_web_inbox/README.rst
+++ b/ssi_web_inbox/README.rst
@@ -31,18 +31,27 @@ Odoo 14 marks a message as "seen" through the *needaction* mechanism:
 That is not a read/unread flag the way an e-mail client has one — in Gmail a
 message that has been opened stays in the Inbox, it only stops being bold.
 
-No field on ``mail.message`` records "this user has read this message" without
-also taking the message out of the Inbox, so a Gmail-like inbox view has no
-data to decide which rows to render as bold.
+The Discuss screen has the matching limitation: every message is rendered in
+full, as a chronological chat, so a cross-record Inbox cannot be scanned. A
+user cannot look at twenty messages at once and then pick one to read.
 
-This module adds that missing state. ``mail.message`` gains a read/unread flag
-**per user**, stored independently from *needaction*, readable from the web
-client through ``_message_format`` and changeable through RPC methods.
+This module fixes both halves.
+
+Server side, ``mail.message`` gains a read/unread flag **per user**, stored
+independently from *needaction*, readable from the web client through
+``_message_format`` and changeable through RPC methods.
+
+Client side, the Discuss menu opens a Gmail-like inbox: the mailbox sidebar
+stays on the left, but messages are listed as compact rows showing the author,
+the record name, a one line preview of the body and the date. Clicking a row
+expands the full message in place, together with the buttons needed to answer
+it or to log a note on the document the message came from. Unread rows are
+bold, and opening one marks it as read.
 
 Nothing of the standard behaviour changes: ``set_message_done``, the
 *needaction* counters and the Inbox mailbox all keep working exactly as
-before. The module only adds state; rendering an inbox with it is out of
-scope here.
+before, and the standard ``mail.action_discuss`` client action is left
+untouched so that modules referencing it stay valid.
 
 **Table of contents**
 
@@ -52,8 +61,29 @@ scope here.
 Usage
 =====
 
-This module has no user interface of its own. It exposes state that other
-modules build on.
+Using the inbox
+~~~~~~~~~~~~~~~
+
+Open the **Discuss** menu. The mailbox sidebar (Inbox, Starred, History,
+channels) is the standard one and behaves as usual; the message area is what
+changed.
+
+* Every message is one row: author, record name, a one line preview of the
+  body, and the date. Hovering the date shows the full timestamp.
+* **Click a row** to open the full message underneath it, and click it again
+  to fold it back. Folding does not change the read state.
+* Rows that you have not read yet are **bold**. Opening a row marks it as
+  read; the envelope button on the right of the row flips the state back and
+  forth without opening anything.
+* An open row offers **Send message** and **Log note**. Both write to the
+  document the message came from, the first as a public message
+  (``mail.mt_comment``), the second as an internal note (``mail.mt_note``).
+  Messages that belong to no document — Odoo notifications, for instance —
+  show no such buttons.
+
+Nothing here changes the standard Discuss client action: only the menu is
+re-pointed, so ``mail.action_discuss`` still exists and still opens the
+standard conversation view for whoever calls it directly.
 
 Server side
 ~~~~~~~~~~~
@@ -100,6 +130,13 @@ it travels with every ``_message_format()`` payload. The client side
 
 There is no bus notification when the state changes, so several tabs open on
 the same session are not kept in sync.
+
+The inbox itself is the client action ``ssi_web_inbox.inbox``, declared by
+``ssi_web_inbox.action_inbox``. It extends the standard ``DiscussWidget``, so
+the control panel, the search bar and the mailbox selection are inherited
+untouched; only the rendering of the message list is replaced, and only when
+the list is shown inside Discuss — the chatter of a form view and the chat
+windows keep the standard conversation rendering.
 
 Bug Tracker
 ===========

--- a/ssi_web_inbox/__manifest__.py
+++ b/ssi_web_inbox/__manifest__.py
@@ -20,6 +20,11 @@
     ],
     "data": [
         "views/assets.xml",
+        "views/inbox_action.xml",
+    ],
+    "qweb": [
+        "static/src/xml/inbox_message_row.xml",
+        "static/src/xml/message_list.xml",
     ],
     "demo": [],
 }

--- a/ssi_web_inbox/readme/DESCRIPTION.rst
+++ b/ssi_web_inbox/readme/DESCRIPTION.rst
@@ -3,15 +3,24 @@ Odoo 14 marks a message as "seen" through the *needaction* mechanism:
 That is not a read/unread flag the way an e-mail client has one — in Gmail a
 message that has been opened stays in the Inbox, it only stops being bold.
 
-No field on ``mail.message`` records "this user has read this message" without
-also taking the message out of the Inbox, so a Gmail-like inbox view has no
-data to decide which rows to render as bold.
+The Discuss screen has the matching limitation: every message is rendered in
+full, as a chronological chat, so a cross-record Inbox cannot be scanned. A
+user cannot look at twenty messages at once and then pick one to read.
 
-This module adds that missing state. ``mail.message`` gains a read/unread flag
-**per user**, stored independently from *needaction*, readable from the web
-client through ``_message_format`` and changeable through RPC methods.
+This module fixes both halves.
+
+Server side, ``mail.message`` gains a read/unread flag **per user**, stored
+independently from *needaction*, readable from the web client through
+``_message_format`` and changeable through RPC methods.
+
+Client side, the Discuss menu opens a Gmail-like inbox: the mailbox sidebar
+stays on the left, but messages are listed as compact rows showing the author,
+the record name, a one line preview of the body and the date. Clicking a row
+expands the full message in place, together with the buttons needed to answer
+it or to log a note on the document the message came from. Unread rows are
+bold, and opening one marks it as read.
 
 Nothing of the standard behaviour changes: ``set_message_done``, the
 *needaction* counters and the Inbox mailbox all keep working exactly as
-before. The module only adds state; rendering an inbox with it is out of
-scope here.
+before, and the standard ``mail.action_discuss`` client action is left
+untouched so that modules referencing it stay valid.

--- a/ssi_web_inbox/readme/USAGE.rst
+++ b/ssi_web_inbox/readme/USAGE.rst
@@ -1,5 +1,26 @@
-This module has no user interface of its own. It exposes state that other
-modules build on.
+Using the inbox
+~~~~~~~~~~~~~~~
+
+Open the **Discuss** menu. The mailbox sidebar (Inbox, Starred, History,
+channels) is the standard one and behaves as usual; the message area is what
+changed.
+
+* Every message is one row: author, record name, a one line preview of the
+  body, and the date. Hovering the date shows the full timestamp.
+* **Click a row** to open the full message underneath it, and click it again
+  to fold it back. Folding does not change the read state.
+* Rows that you have not read yet are **bold**. Opening a row marks it as
+  read; the envelope button on the right of the row flips the state back and
+  forth without opening anything.
+* An open row offers **Send message** and **Log note**. Both write to the
+  document the message came from, the first as a public message
+  (``mail.mt_comment``), the second as an internal note (``mail.mt_note``).
+  Messages that belong to no document — Odoo notifications, for instance —
+  show no such buttons.
+
+Nothing here changes the standard Discuss client action: only the menu is
+re-pointed, so ``mail.action_discuss`` still exists and still opens the
+standard conversation view for whoever calls it directly.
 
 Server side
 ~~~~~~~~~~~
@@ -46,3 +67,10 @@ it travels with every ``_message_format()`` payload. The client side
 
 There is no bus notification when the state changes, so several tabs open on
 the same session are not kept in sync.
+
+The inbox itself is the client action ``ssi_web_inbox.inbox``, declared by
+``ssi_web_inbox.action_inbox``. It extends the standard ``DiscussWidget``, so
+the control panel, the search bar and the mailbox selection are inherited
+untouched; only the rendering of the message list is replaced, and only when
+the list is shown inside Discuss — the chatter of a form view and the chat
+windows keep the standard conversation rendering.

--- a/ssi_web_inbox/static/description/index.html
+++ b/ssi_web_inbox/static/description/index.html
@@ -379,39 +379,68 @@ ul.auto-toc {
 <tt class="docutils literal">set_message_done</tt> removes the message from Inbox and moves it to History.
 That is not a read/unread flag the way an e-mail client has one — in Gmail a
 message that has been opened stays in the Inbox, it only stops being bold.</p>
-<p>No field on <tt class="docutils literal">mail.message</tt> records “this user has read this message” without
-also taking the message out of the Inbox, so a Gmail-like inbox view has no
-data to decide which rows to render as bold.</p>
-<p>This module adds that missing state. <tt class="docutils literal">mail.message</tt> gains a read/unread flag
-<strong>per user</strong>, stored independently from <em>needaction</em>, readable from the web
-client through <tt class="docutils literal">_message_format</tt> and changeable through RPC methods.</p>
+<p>The Discuss screen has the matching limitation: every message is rendered in
+full, as a chronological chat, so a cross-record Inbox cannot be scanned. A
+user cannot look at twenty messages at once and then pick one to read.</p>
+<p>This module fixes both halves.</p>
+<p>Server side, <tt class="docutils literal">mail.message</tt> gains a read/unread flag <strong>per user</strong>, stored
+independently from <em>needaction</em>, readable from the web client through
+<tt class="docutils literal">_message_format</tt> and changeable through RPC methods.</p>
+<p>Client side, the Discuss menu opens a Gmail-like inbox: the mailbox sidebar
+stays on the left, but messages are listed as compact rows showing the author,
+the record name, a one line preview of the body and the date. Clicking a row
+expands the full message in place, together with the buttons needed to answer
+it or to log a note on the document the message came from. Unread rows are
+bold, and opening one marks it as read.</p>
 <p>Nothing of the standard behaviour changes: <tt class="docutils literal">set_message_done</tt>, the
 <em>needaction</em> counters and the Inbox mailbox all keep working exactly as
-before. The module only adds state; rendering an inbox with it is out of
-scope here.</p>
+before, and the standard <tt class="docutils literal">mail.action_discuss</tt> client action is left
+untouched so that modules referencing it stay valid.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#usage" id="toc-entry-1">Usage</a><ul>
-<li><a class="reference internal" href="#server-side" id="toc-entry-2">Server side</a></li>
-<li><a class="reference internal" href="#client-side" id="toc-entry-3">Client side</a></li>
+<li><a class="reference internal" href="#using-the-inbox" id="toc-entry-2">Using the inbox</a></li>
+<li><a class="reference internal" href="#server-side" id="toc-entry-3">Server side</a></li>
+<li><a class="reference internal" href="#client-side" id="toc-entry-4">Client side</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-4">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-5">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-6">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-7">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-8">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-5">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-6">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-7">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-8">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-9">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
 <div class="section" id="usage">
 <h2><a class="toc-backref" href="#toc-entry-1">Usage</a></h2>
-<p>This module has no user interface of its own. It exposes state that other
-modules build on.</p>
+<div class="section" id="using-the-inbox">
+<h3><a class="toc-backref" href="#toc-entry-2">Using the inbox</a></h3>
+<p>Open the <strong>Discuss</strong> menu. The mailbox sidebar (Inbox, Starred, History,
+channels) is the standard one and behaves as usual; the message area is what
+changed.</p>
+<ul class="simple">
+<li>Every message is one row: author, record name, a one line preview of the
+body, and the date. Hovering the date shows the full timestamp.</li>
+<li><strong>Click a row</strong> to open the full message underneath it, and click it again
+to fold it back. Folding does not change the read state.</li>
+<li>Rows that you have not read yet are <strong>bold</strong>. Opening a row marks it as
+read; the envelope button on the right of the row flips the state back and
+forth without opening anything.</li>
+<li>An open row offers <strong>Send message</strong> and <strong>Log note</strong>. Both write to the
+document the message came from, the first as a public message
+(<tt class="docutils literal">mail.mt_comment</tt>), the second as an internal note (<tt class="docutils literal">mail.mt_note</tt>).
+Messages that belong to no document — Odoo notifications, for instance —
+show no such buttons.</li>
+</ul>
+<p>Nothing here changes the standard Discuss client action: only the menu is
+re-pointed, so <tt class="docutils literal">mail.action_discuss</tt> still exists and still opens the
+standard conversation view for whoever calls it directly.</p>
+</div>
 <div class="section" id="server-side">
-<h3><a class="toc-backref" href="#toc-entry-2">Server side</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-3">Server side</a></h3>
 <p><tt class="docutils literal">mail.message</tt> gains two fields:</p>
 <table border="1" class="docutils">
 <colgroup>
@@ -451,7 +480,7 @@ messages.inbox_toggle_read()
 user cannot flag a message they may not see.</p>
 </div>
 <div class="section" id="client-side">
-<h3><a class="toc-backref" href="#toc-entry-3">Client side</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-4">Client side</a></h3>
 <p><tt class="docutils literal">inbox_read_partner_ids</tt> is appended to <tt class="docutils literal">_get_message_format_fields()</tt>, so
 it travels with every <tt class="docutils literal">_message_format()</tt> payload. The client side
 <tt class="docutils literal">mail.message</tt> model is patched accordingly and gains:</p>
@@ -463,10 +492,16 @@ method and then update the local state.</li>
 </ul>
 <p>There is no bus notification when the state changes, so several tabs open on
 the same session are not kept in sync.</p>
+<p>The inbox itself is the client action <tt class="docutils literal">ssi_web_inbox.inbox</tt>, declared by
+<tt class="docutils literal">ssi_web_inbox.action_inbox</tt>. It extends the standard <tt class="docutils literal">DiscussWidget</tt>, so
+the control panel, the search bar and the mailbox selection are inherited
+untouched; only the rendering of the message list is replaced, and only when
+the list is shown inside Discuss — the chatter of a form view and the chat
+windows keep the standard conversation rendering.</p>
 </div>
 </div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-4">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/open-synergy/ssi-web/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -474,22 +509,22 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-5">Credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Credits</a></h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-6">Authors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-7">Authors</a></h3>
 <ul class="simple">
 <li>OpenSynergy Indonesia</li>
 <li>PT. Simetri Sinergi Indonesia</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#toc-entry-7">Contributors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-8">Contributors</a></h3>
 <ul class="simple">
 <li>Andhitia Rama &lt;<a class="reference external" href="mailto:andhitia.r&#64;gmail.com">andhitia.r&#64;gmail.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-9">Maintainers</a></h3>
 <p>This module is part of the <a class="reference external" href="https://github.com/open-synergy/ssi-web/tree/14.0/ssi_web_inbox">open-synergy/ssi-web</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>

--- a/ssi_web_inbox/static/src/js/components/inbox_message_row.js
+++ b/ssi_web_inbox/static/src/js/components/inbox_message_row.js
@@ -1,0 +1,255 @@
+odoo.define("ssi_web_inbox.InboxMessageRow", function (require) {
+    "use strict";
+
+    const components = {
+        Composer: require("mail/static/src/components/composer/composer.js"),
+        Message: require("mail/static/src/components/message/message.js"),
+    };
+    const useShouldUpdateBasedOnProps = require("mail/static/src/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props.js");
+    const useStore = require("mail/static/src/component_hooks/use_store/use_store.js");
+
+    const {getMessagePreview} = require("ssi_web_inbox.message_preview");
+
+    const {getLangDatetimeFormat} = require("web.time");
+
+    const {Component, useState} = owl;
+
+    /**
+     * One scannable row of the Gmail like inbox.
+     *
+     * Closed, the row is a single line: author, record name, a plain text
+     * preview of the body and the date. Opened, the very same row also
+     * renders the full message through the core `Message` component, plus
+     * the buttons needed to answer it. The open state is deliberately kept
+     * local: it is a pure display concern, nothing on the server or in the
+     * messaging models has to know which rows a user unfolded.
+     */
+    class InboxMessageRow extends Component {
+        /**
+         * @override
+         */
+        constructor(...args) {
+            super(...args);
+            this.state = useState({
+                /**
+                 * Whether the composer is shown under the open message.
+                 */
+                hasComposer: false,
+                /**
+                 * Whether the full message is shown under the summary.
+                 */
+                isOpen: false,
+            });
+            useShouldUpdateBasedOnProps();
+            useStore((props) => {
+                const message = this.env.models["mail.message"].get(
+                    props.messageLocalId
+                );
+                const author = message ? message.author : undefined;
+                const originThread = message ? message.originThread : undefined;
+                const composer = originThread ? originThread.composer : undefined;
+                return {
+                    author,
+                    authorNameOrDisplayName: author && author.nameOrDisplayName,
+                    composer,
+                    composerIsLog: composer && composer.isLog,
+                    message: message ? message.__state : undefined,
+                    originThread,
+                    originThreadName: originThread && originThread.name,
+                };
+            });
+        }
+
+        // ----------------------------------------------------------------
+        // Public
+        // ----------------------------------------------------------------
+
+        /**
+         * Name shown as the sender of the row.
+         *
+         * Mirrors what the core message header does: the author when there
+         * is one, the raw e-mail address for an incoming e-mail without a
+         * matching partner, and a neutral label otherwise.
+         *
+         * @returns {String}
+         */
+        get authorName() {
+            const message = this.message;
+            if (!message) {
+                return "";
+            }
+            if (message.author) {
+                return message.author.nameOrDisplayName;
+            }
+            if (message.email_from) {
+                return message.email_from;
+            }
+            return this.env._t("Anonymous");
+        }
+
+        /**
+         * Composer of the thread the message originates from.
+         *
+         * Answering happens on the document the message belongs to, not on
+         * the mailbox being browsed, so the composer is taken from the
+         * origin thread. Mailbox only messages have none.
+         *
+         * @returns {mail.composer|undefined}
+         */
+        get composer() {
+            const message = this.message;
+            return message && message.originThread
+                ? message.originThread.composer
+                : undefined;
+        }
+
+        /**
+         * Full date of the message, used as the title of the short date.
+         *
+         * @returns {String}
+         */
+        get datetime() {
+            const message = this.message;
+            return message && message.date
+                ? message.date.format(getLangDatetimeFormat())
+                : "";
+        }
+
+        /**
+         * Record this component displays.
+         *
+         * @returns {mail.message|undefined}
+         */
+        get message() {
+            return this.env.models["mail.message"].get(this.props.messageLocalId);
+        }
+
+        /**
+         * One line plain text excerpt of the body.
+         *
+         * @returns {String}
+         */
+        get preview() {
+            const message = this.message;
+            return message ? getMessagePreview(message.body) : "";
+        }
+
+        /**
+         * Name of the document the message is attached to.
+         *
+         * @returns {String}
+         */
+        get recordName() {
+            const message = this.message;
+            return message && message.originThread && message.originThread.name
+                ? message.originThread.name
+                : "";
+        }
+
+        /**
+         * Label of the button flipping the read state.
+         *
+         * @returns {String}
+         */
+        get toggleReadTitle() {
+            const message = this.message;
+            return message && message.isInboxRead
+                ? this.env._t("Mark as unread")
+                : this.env._t("Mark as read");
+        }
+
+        // ----------------------------------------------------------------
+        // Handlers
+        // ----------------------------------------------------------------
+
+        /**
+         * Show the composer as a note on the origin thread.
+         *
+         * `isLog` drives the subtype the composer posts with, so it is set
+         * before the composer is displayed rather than when the message is
+         * sent.
+         *
+         * @private
+         */
+        _onClickLogNote() {
+            const composer = this.composer;
+            if (!composer) {
+                return;
+            }
+            composer.update({isLog: true});
+            this.state.hasComposer = true;
+        }
+
+        /**
+         * Show the composer as a public message on the origin thread.
+         *
+         * @private
+         */
+        _onClickSendMessage() {
+            const composer = this.composer;
+            if (!composer) {
+                return;
+            }
+            composer.update({isLog: false});
+            this.state.hasComposer = true;
+        }
+
+        /**
+         * Fold or unfold the row.
+         *
+         * Unfolding also marks the message as read, the way opening a mail
+         * does in an e-mail client. Folding it back leaves the read state
+         * alone: a message that has been read stays read.
+         *
+         * @private
+         */
+        _onClickSummary() {
+            if (this.state.isOpen) {
+                this.state.isOpen = false;
+                this.state.hasComposer = false;
+                return;
+            }
+            this.state.isOpen = true;
+            const message = this.message;
+            if (message && !message.isInboxRead) {
+                message.setInboxRead();
+            }
+        }
+
+        /**
+         * Flip the read state of the message without opening it.
+         *
+         * @private
+         */
+        _onClickToggleRead() {
+            const message = this.message;
+            if (message) {
+                message.toggleInboxRead();
+            }
+        }
+    }
+
+    Object.assign(InboxMessageRow, {
+        components,
+        defaultProps: {
+            hasCheckbox: false,
+            hasMarkAsReadIcon: false,
+            hasReplyIcon: false,
+            isSelected: false,
+        },
+        props: {
+            hasCheckbox: Boolean,
+            hasMarkAsReadIcon: Boolean,
+            hasReplyIcon: Boolean,
+            isSelected: Boolean,
+            messageLocalId: String,
+            threadViewLocalId: {
+                type: String,
+                optional: true,
+            },
+        },
+        template: "ssi_web_inbox.InboxMessageRow",
+    });
+
+    return InboxMessageRow;
+});

--- a/ssi_web_inbox/static/src/js/components/message_list.js
+++ b/ssi_web_inbox/static/src/js/components/message_list.js
@@ -1,0 +1,19 @@
+odoo.define("ssi_web_inbox.MessageList", function (require) {
+    "use strict";
+
+    const MessageList = require("mail/static/src/components/message_list/message_list.js");
+
+    const InboxMessageRow = require("ssi_web_inbox.InboxMessageRow");
+
+    /**
+     * Make the inbox row reachable from the `mail.MessageList` template.
+     *
+     * OWL resolves a sub-component through `constructor.components` of the
+     * component owning the template, so extending the template of
+     * `MessageList` is not enough on its own: the class has to know the
+     * component the added markup refers to.
+     */
+    Object.assign(MessageList.components, {InboxMessageRow});
+
+    return MessageList;
+});

--- a/ssi_web_inbox/static/src/js/utils/message_preview.js
+++ b/ssi_web_inbox/static/src/js/utils/message_preview.js
@@ -1,0 +1,51 @@
+odoo.define("ssi_web_inbox.message_preview", function () {
+    "use strict";
+
+    const DEFAULT_MAX_LENGTH = 120;
+
+    /**
+     * Decode the HTML entities left in a tag free text fragment.
+     *
+     * The fragment is assigned as the inner HTML of a detached textarea and
+     * read back through its value. A textarea is used on purpose: its
+     * content model is raw text, so no markup can be interpreted and no
+     * script can be executed while decoding.
+     *
+     * @private
+     * @param {String} text fragment that no longer contains any tag
+     * @returns {String} the same fragment with its entities decoded
+     */
+    function _decodeEntities(text) {
+        const textarea = document.createElement("textarea");
+        textarea.innerHTML = text;
+        return textarea.value;
+    }
+
+    /**
+     * Build a one line plain text preview out of a message body.
+     *
+     * The body of a message is HTML, which cannot be shown as is on a
+     * compact row: tags have to go, entities have to become readable
+     * characters and the result has to fit on a single line. Tags are
+     * replaced by a space instead of being dropped, so that
+     * "<p>a</p><p>b</p>" reads as "a b" rather than "ab".
+     *
+     * @param {String} body HTML body of a message, may be empty
+     * @param {Number} [maxLength=120] maximum number of characters kept,
+     *   ellipsis excluded
+     * @returns {String} the preview, empty when there is nothing to show
+     */
+    function getMessagePreview(body, maxLength = DEFAULT_MAX_LENGTH) {
+        if (!body) {
+            return "";
+        }
+        const withoutTags = String(body).replace(/<[^>]*>/g, " ");
+        const collapsed = _decodeEntities(withoutTags).replace(/\s+/g, " ").trim();
+        if (collapsed.length <= maxLength) {
+            return collapsed;
+        }
+        return collapsed.slice(0, maxLength).trimEnd() + "…";
+    }
+
+    return {getMessagePreview};
+});

--- a/ssi_web_inbox/static/src/js/widgets/inbox.js
+++ b/ssi_web_inbox/static/src/js/widgets/inbox.js
@@ -1,0 +1,37 @@
+odoo.define("ssi_web_inbox.InboxWidget", function (require) {
+    "use strict";
+
+    const DiscussWidget = require("mail/static/src/widgets/discuss/discuss.js");
+
+    const {action_registry} = require("web.core");
+
+    /**
+     * Client action backing the Gmail like inbox.
+     *
+     * It extends the standard Discuss action instead of replacing it, so
+     * the control panel, the search bar and the mailbox selection are
+     * inherited as they are. What changes is rendered further down, in the
+     * message list, and the action is registered under its own tag so that
+     * `mail.widgets.discuss` keeps working for whoever still uses it.
+     */
+    const InboxWidget = DiscussWidget.extend({
+        /**
+         * Tag the root element of the action.
+         *
+         * The stylesheet of this module hangs on that class, so the inbox
+         * look is confined to this action and cannot leak into another
+         * screen embedding the same messaging components.
+         *
+         * @override {web.AbstractAction}
+         * @returns {Promise}
+         */
+        async start() {
+            await this._super(...arguments);
+            this.el.classList.add("o_InboxAction");
+        },
+    });
+
+    action_registry.add("ssi_web_inbox.inbox", InboxWidget);
+
+    return InboxWidget;
+});

--- a/ssi_web_inbox/static/src/scss/inbox.scss
+++ b/ssi_web_inbox/static/src/scss/inbox.scss
@@ -1,0 +1,80 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+.o_InboxMessageRow {
+    display: block;
+    width: 100%;
+    border-bottom: 1px solid #e9ecef;
+    background-color: #fff;
+
+    &.o-open {
+        background-color: #f8f9fa;
+    }
+}
+
+.o_InboxMessageRow_summary {
+    display: flex;
+    align-items: baseline;
+    padding: 6px 12px;
+    cursor: pointer;
+    // A row is a single scannable line: nothing may wrap and push the
+    // next row down.
+    white-space: nowrap;
+    overflow: hidden;
+
+    &:hover {
+        background-color: #f1f3f5;
+    }
+}
+
+// Unread rows are bold, the way an unread mail is in an e-mail client.
+// The whole line is emphasised, not only the author.
+.o_InboxMessageRow.o-unread .o_InboxMessageRow_summary {
+    font-weight: bold;
+}
+
+.o_InboxMessageRow_author {
+    flex: 0 0 auto;
+    width: 180px;
+    padding-right: 8px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.o_InboxMessageRow_record {
+    flex: 0 0 auto;
+    max-width: 220px;
+    padding-right: 8px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: #6c757d;
+}
+
+.o_InboxMessageRow_preview {
+    flex: 1 1 auto;
+    padding-right: 8px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: #6c757d;
+}
+
+.o_InboxMessageRow_date {
+    flex: 0 0 auto;
+    padding-right: 8px;
+    color: #6c757d;
+}
+
+.o_InboxMessageRow_toggleRead {
+    flex: 0 0 auto;
+    padding: 0 4px;
+    line-height: 1;
+}
+
+.o_InboxMessageRow_content {
+    padding: 0 12px 8px 12px;
+}
+
+.o_InboxMessageRow_commands {
+    padding-left: 8px;
+}

--- a/ssi_web_inbox/static/src/xml/inbox_message_row.xml
+++ b/ssi_web_inbox/static/src/xml/inbox_message_row.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/AGPL). -->
+<templates xml:space="preserve">
+    <t t-name="ssi_web_inbox.InboxMessageRow" owl="1">
+        <div
+            class="o_InboxMessageRow"
+            t-att-class="{
+                'o-open': state.isOpen,
+                'o-unread': !message.isInboxRead,
+            }"
+        >
+            <div class="o_InboxMessageRow_summary" t-on-click="_onClickSummary">
+                <span class="o_InboxMessageRow_author" t-esc="authorName" />
+                <span class="o_InboxMessageRow_record" t-esc="recordName" />
+                <span class="o_InboxMessageRow_preview" t-esc="preview" />
+                <span
+                    class="o_InboxMessageRow_date"
+                    t-att-title="datetime"
+                    t-esc="message.dateFromNow"
+                />
+                <button
+                    class="o_InboxMessageRow_toggleRead btn btn-link"
+                    type="button"
+                    t-att-title="toggleReadTitle"
+                    t-att-aria-label="toggleReadTitle"
+                    t-on-click.stop="_onClickToggleRead"
+                >
+                    <i
+                        class="fa"
+                        t-att-class="message.isInboxRead ? 'fa-envelope-o' : 'fa-envelope-open-o'"
+                        role="img"
+                    />
+                </button>
+            </div>
+            <t t-if="state.isOpen">
+                <div class="o_InboxMessageRow_content">
+                    <Message
+                        class="o_InboxMessageRow_message"
+                        hasCheckbox="props.hasCheckbox"
+                        hasMarkAsReadIcon="props.hasMarkAsReadIcon"
+                        hasReplyIcon="props.hasReplyIcon"
+                        isSelected="props.isSelected"
+                        isSquashed="false"
+                        messageLocalId="props.messageLocalId"
+                        threadViewLocalId="props.threadViewLocalId"
+                    />
+                    <t t-if="composer">
+                        <div class="o_InboxMessageRow_commands">
+                            <button
+                                class="o_InboxMessageRow_buttonSendMessage btn btn-link"
+                                type="button"
+                                t-on-click="_onClickSendMessage"
+                            >Send message</button>
+                            <button
+                                class="o_InboxMessageRow_buttonLogNote btn btn-link"
+                                type="button"
+                                t-on-click="_onClickLogNote"
+                            >Log note</button>
+                        </div>
+                        <t t-if="state.hasComposer">
+                            <Composer
+                                class="o_InboxMessageRow_composer"
+                                composerLocalId="composer.localId"
+                                isExpandable="true"
+                            />
+                        </t>
+                    </t>
+                </div>
+            </t>
+        </div>
+    </t>
+</templates>

--- a/ssi_web_inbox/static/src/xml/message_list.xml
+++ b/ssi_web_inbox/static/src/xml/message_list.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/AGPL). -->
+<templates xml:space="preserve">
+    <!-- Only Discuss shows scannable rows. The very same message list also
+         renders the chatter of every form view and the chat windows, which
+         must keep the standard conversation rendering, hence the guard on
+         the thread viewer. -->
+    <t t-inherit="mail.MessageList" t-inherit-mode="extension">
+        <xpath expr="//Message" position="replace">
+            <t t-if="threadView.threadViewer.discuss">
+                <InboxMessageRow
+                    class="o_MessageList_item o_MessageList_message"
+                    hasCheckbox="props.hasMessageCheckbox"
+                    hasMarkAsReadIcon="props.haveMessagesMarkAsReadIcon"
+                    hasReplyIcon="props.haveMessagesReplyIcon"
+                    isSelected="props.selectedMessageLocalId === message.localId"
+                    messageLocalId="message.localId"
+                    threadViewLocalId="threadView.localId"
+                    t-ref="{{ message.localId }}"
+                />
+            </t>
+            <t t-else="">$0</t>
+        </xpath>
+    </t>
+</templates>

--- a/ssi_web_inbox/tests/__init__.py
+++ b/ssi_web_inbox/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/AGPL).
 
 from . import test_ssi_web_inbox
+from . import test_ssi_web_inbox_action

--- a/ssi_web_inbox/tests/test_data_ssi_web_inbox_action.yaml
+++ b/ssi_web_inbox/tests/test_data_ssi_web_inbox_action.yaml
@@ -1,0 +1,43 @@
+options:
+  auto_refresh: true
+
+scenarios:
+  - name: "ssi_web_inbox - The inbox client action is registered"
+    steps:
+      - step: "Resolve the inbox client action"
+        action: "ref"
+        xml_id: "ssi_web_inbox.action_inbox"
+        save_as: "inbox_action"
+      - step: "Assert it opens the inbox client tag on the mailbox model"
+        action: "assert"
+        target: "inbox_action"
+        asserts:
+          name:
+            type: "value"
+            expected: "Discuss"
+          tag:
+            type: "value"
+            expected: "ssi_web_inbox.inbox"
+          res_model:
+            type: "value"
+            expected: "mail.channel"
+
+  # Re-pointing the menu must not damage the standard action: other modules
+  # reference mail.action_discuss and would break if it disappeared or
+  # started opening something else.
+  - name: "ssi_web_inbox - The standard Discuss action is left untouched"
+    steps:
+      - step: "Resolve the standard Discuss action"
+        action: "ref"
+        xml_id: "mail.action_discuss"
+        save_as: "discuss_action"
+      - step: "Assert it still exists with its own client tag"
+        action: "assert"
+        target: "discuss_action"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+          tag:
+            type: "value"
+            expected: "mail.widgets.discuss"

--- a/ssi_web_inbox/tests/test_ssi_web_inbox_action.py
+++ b/ssi_web_inbox/tests/test_ssi_web_inbox_action.py
@@ -1,0 +1,37 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/AGPL).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSsiWebInboxAction(YamlTransactionCase):
+    """Cover the inbox client action and the Discuss menu override."""
+
+    def test_ssi_web_inbox_action(self):
+        """Run the client action scenarios."""
+        self.run_yaml_scenario("test_data_ssi_web_inbox_action.yaml")
+
+    def test_discuss_menu_opens_the_inbox_action(self):
+        """Assert the Discuss menu was re-pointed to the inbox action.
+
+        The negative half of the assertion matters as much as the
+        positive one: adding a client action that nothing opens would
+        satisfy the scenarios above while leaving the menu on the
+        standard Discuss action.
+
+        Pure Python — triggers P1 (L-01: the value under test is what
+        ``menu.action`` returns, and ``action: call`` discards return
+        values; L-02: the actual side of a YAML assert is a dotted
+        ``getattr`` on a record of the registry, so neither the model of
+        a ``Reference`` field nor an inequality against another record
+        can be expressed there).
+        """
+        menu = self.env.ref("mail.menu_root_discuss")
+        action = menu.action
+        self.assertEqual(action._name, "ir.actions.client")
+        self.assertEqual(action.tag, "ssi_web_inbox.inbox")
+        self.assertNotEqual(action, self.env.ref("mail.action_discuss"))

--- a/ssi_web_inbox/views/assets.xml
+++ b/ssi_web_inbox/views/assets.xml
@@ -9,9 +9,26 @@
         inherit_id="web.assets_backend"
     >
         <xpath expr="." position="inside">
+            <link rel="stylesheet" href="/ssi_web_inbox/static/src/scss/inbox.scss" />
             <script
                 type="text/javascript"
                 src="/ssi_web_inbox/static/src/js/models/message.js"
+            />
+            <script
+                type="text/javascript"
+                src="/ssi_web_inbox/static/src/js/utils/message_preview.js"
+            />
+            <script
+                type="text/javascript"
+                src="/ssi_web_inbox/static/src/js/components/inbox_message_row.js"
+            />
+            <script
+                type="text/javascript"
+                src="/ssi_web_inbox/static/src/js/components/message_list.js"
+            />
+            <script
+                type="text/javascript"
+                src="/ssi_web_inbox/static/src/js/widgets/inbox.js"
             />
         </xpath>
     </template>

--- a/ssi_web_inbox/views/inbox_action.xml
+++ b/ssi_web_inbox/views/inbox_action.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/AGPL). -->
+<odoo>
+    <!-- Same shape as mail.action_discuss so the mailbox sidebar of the core
+         Discuss component keeps working as is; only the client tag differs. -->
+    <record id="action_inbox" model="ir.actions.client">
+        <field name="name">Discuss</field>
+        <field name="tag">ssi_web_inbox.inbox</field>
+        <field name="res_model">mail.channel</field>
+        <field
+            name="params"
+            eval="&quot;{ 'default_active_id': 'mail.box_inbox' }&quot;"
+        />
+    </record>
+    <!-- Only the menu is re-pointed. mail.action_discuss is left untouched so
+         modules referencing it stay valid. -->
+    <record id="mail.menu_root_discuss" model="ir.ui.menu">
+        <field name="action" ref="ssi_web_inbox.action_inbox" />
+    </record>
+</odoo>


### PR DESCRIPTION
Menu Discuss kini membuka client action `ssi_web_inbox.inbox` yang menampilkan pesan sebagai baris ringkas yang bisa dipindai, dibuka di tempat, dan dijawab langsung.

- Record `ir.actions.client` `ssi_web_inbox.action_inbox` + override menuitem `mail.menu_root_discuss`. Record `mail.action_discuss` tidak disentuh.
- Client action legacy meng-extend `DiscussWidget` bawaan (control panel, search bar, sidebar mailbox diwarisi).
- Komponen OWL baris pesan ringkas (author, nama record, preview body, tanggal) + expand di tempat yang merender komponen core `mail.Message`.
- Read/unread: baris tebal saat belum dibaca, `setInboxRead()` saat dibuka, tombol toggle per baris; menutup baris tidak mengubah state read.
- Reply & log note lewat `originThread.composer.isLog` + komponen core `Composer`.
- Helper `getMessagePreview`, SCSS, aset XML + key `qweb`, dan unit test untuk record action serta override menu.

Closes #85