### PR TITLE
[UPD] ssi_web_hierarchy_view: pencarian hirarkis pada view hierarchy

### DIFF
--- a/ssi_web_hierarchy_view/README.rst
+++ b/ssi_web_hierarchy_view/README.rst
@@ -19,10 +19,9 @@ organizational structure, ...) can be browsed as a tree instead of only as a
 flat list or through a ``child_of`` filter.
 
 This iteration is **read only**: dragging a row to reparent it, inline edit
-and ``groupBy`` are out of scope. Searching within the hierarchy,
-``decoration-*``, a sticky header beyond the column headers, keyboard
-navigation and numeric column aggregation (``sum=``) are not implemented
-either.
+and ``groupBy`` are out of scope. ``decoration-*``, a sticky header beyond
+the column headers, keyboard navigation and numeric column aggregation
+(``sum=``) are not implemented either.
 
 Usage
 =====
@@ -101,6 +100,47 @@ survives navigating to the form view and back through the breadcrumb.
 Only the root level is paginated (80 per page, using the same pager as a
 list view); the children of an expanded node are never paginated.
 
+Searching the hierarchy
+-----------------------
+
+Filtering from the search view does **not** filter the root level only: a
+record matching the filter is shown wherever it sits in the tree, together
+with its whole parent chain, and that chain comes already expanded. So a
+match five levels deep is reachable in one filter instead of five manual
+expansions.
+
+* A row that matched the filter carries the class ``o_hierarchy_match`` and
+  is highlighted.
+* A row present only because it is an ancestor of a match carries the class
+  ``o_hierarchy_context`` and is **not** highlighted, so it reads as
+  context rather than as a result.
+* ``default_expand`` has no say while a filter is active: what is expanded
+  is exactly the chains leading to the matches. Clearing the filter goes
+  back to the full tree, ``default_expand`` included.
+* ``limit`` caps the number of **matches** here, not the number of nodes
+  kept in memory. When it cuts the result short, the same warning
+  notification as **Expand All** is shown. The pager is hidden while a
+  filter is active: the result is a tree of matches, not a page of roots.
+
+The matches and their ancestors are resolved by a single call to
+``hierarchy_search_ancestors(domain, parent_field, limit=None)``, a method
+this module adds to every model. It returns ``matches`` (ids matching the
+domain, in the model's ``_order``), ``ancestors`` (ids of their ancestors
+that do not match the domain themselves) and ``truncated``. Access rights
+are honoured — there is no ``sudo()``: an ancestor the user may not read is
+dropped silently, and its child then shows up at the top level of the tree.
+A parent chain longer than 64 levels is treated as cyclic data and raises,
+rather than looping forever.
+
+.. important::
+
+   Hierarchical search needs ``parent_field``. A view declaring only
+   ``child_field`` cannot walk a chain upwards — a record does not know its
+   parent there — so filtering such a view falls back to **flat
+   filtering**: the matching records are listed as roots, without their
+   parent chain, and can still be expanded downwards. Add ``parent_field``
+   next to ``child_field`` to get hierarchical search.
+
 Example
 -------
 
@@ -126,8 +166,11 @@ Known limitations
 
 * Read only: nodes cannot be dragged to reparent them, and there is no
   inline edit.
-* No hierarchical search: matching, highlighting the parent chain of a match,
-  and ``groupBy`` are not part of this iteration.
+* Hierarchical search needs ``parent_field``; a ``child_field``-only view
+  falls back to flat filtering (see *Searching the hierarchy*).
+* No ``groupBy``: grouping records would collide with the hierarchy itself.
+* No client-side search inside the already loaded tree: filtering always
+  goes back to the server.
 * No ``decoration-*`` and no sticky header beyond the column headers.
 * No keyboard navigation.
 * No numeric column aggregation (``sum=``).

--- a/ssi_web_hierarchy_view/models/__init__.py
+++ b/ssi_web_hierarchy_view/models/__init__.py
@@ -2,5 +2,6 @@
 # Copyright 2026 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from . import base  # noqa: F401
 from . import ir_ui_view  # noqa: F401
 from . import ir_actions_act_window_view  # noqa: F401

--- a/ssi_web_hierarchy_view/models/base.py
+++ b/ssi_web_hierarchy_view/models/base.py
@@ -1,0 +1,154 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import _, models
+from odoo.exceptions import UserError
+
+# Maximum number of levels the parent chain is walked upwards. A chain
+# longer than this is treated as cyclic data rather than as a legitimate
+# hierarchy, so the walk raises instead of looping forever.
+HIERARCHY_MAX_DEPTH = 64
+
+
+class Base(models.AbstractModel):
+    """
+    Adds the server side of the hierarchy view's search mode to every
+    model: one single call returns the records matching a domain together
+    with their whole parent chain, so that the browser never has to walk
+    that chain with one RPC per level.
+    """
+
+    _inherit = "base"
+
+    def hierarchy_search_ancestors(self, domain, parent_field, limit=None):
+        """Search ``domain`` and resolve the parent chain of every match.
+
+        Called by the ``hierarchy`` view whenever a search view filter is
+        active. A record matching the filter but buried deep inside the
+        tree has to be shown together with every one of its ancestors,
+        otherwise it stays invisible until the user happens to open the
+        whole chain by hand.
+
+        Access rights are honoured: there is no ``sudo()`` anywhere. An
+        ancestor the current user may not read is dropped silently, and
+        so is everything above it, which makes its child rise to the top
+        level of the displayed tree.
+
+        :param domain: search domain the records have to match
+        :param parent_field: name of the ``many2one`` to this same model
+            carrying the parent of a record
+        :param limit: maximum number of matches, ``None`` for no limit
+        :return: dict with ``matches`` (ids matching ``domain``, ordered
+            by the model ``_order``), ``ancestors`` (ids of the ancestors
+            of those matches that do not match ``domain`` themselves,
+            closest level first) and ``truncated`` (``True`` when
+            ``limit`` cut the matches short)
+        :raises UserError: when ``parent_field`` is not a ``many2one``
+            pointing at this model, or when the parent chain is deeper
+            than ``HIERARCHY_MAX_DEPTH`` levels, which only happens on
+            cyclic data
+        """
+        self._check_hierarchy_parent_field(parent_field)
+        matches = self.search(domain, limit=limit)
+        truncated = bool(limit) and self.search_count(domain) > limit
+        return {
+            "matches": matches.ids,
+            "ancestors": self._hierarchy_ancestor_ids(matches, parent_field),
+            "truncated": truncated,
+        }
+
+    def _check_hierarchy_parent_field(self, parent_field):
+        """Reject a ``parent_field`` that cannot carry a parent chain.
+
+        Extension point: override to accept another way of naming the
+        parent of a record without touching
+        ``hierarchy_search_ancestors`` itself.
+
+        :param parent_field: value of the arch's ``parent_field``
+        :raises UserError: when the field does not exist on this model,
+            or is not a ``many2one`` pointing at this very model
+        """
+        field = self._fields.get(parent_field)
+        if field is None:
+            error_message = _(
+                """
+Context: Search a hierarchy view with a filter
+Database ID: %s
+Problem: Field %s does not exist on model %s
+Solution: Set parent_field of the hierarchy tag to an existing field
+"""
+                % (self.id, parent_field, self._name)
+            )
+            raise UserError(error_message)
+
+        if field.type != "many2one" or field.comodel_name != self._name:
+            error_message = _(
+                """
+Context: Search a hierarchy view with a filter
+Database ID: %s
+Problem: Field %s is not a many2one field of model %s
+Solution: Set parent_field to a many2one field pointing to %s
+"""
+                % (self.id, parent_field, self._name, self._name)
+            )
+            raise UserError(error_message)
+
+    def _hierarchy_ancestor_ids(self, records, parent_field):
+        """Walk ``parent_field`` upwards and collect the ancestors.
+
+        The walk is breadth first, one level per iteration, so a whole
+        level costs a single query no matter how many records it holds.
+        Ancestors that also belong to ``records`` are left out of the
+        result: the caller already reports those as matches. Ancestors
+        the user may not read are dropped, because the lookup of each
+        level goes through ``search`` and therefore through the record
+        rules of the current user.
+
+        :param records: the recordset the walk starts from
+        :param parent_field: name of the ``many2one`` to this same model
+        :return: list of ancestor ids, closest level first
+        :raises UserError: when more than ``HIERARCHY_MAX_DEPTH`` levels
+            are walked, which only happens on cyclic data
+        """
+        ancestor_ids = []
+        seen_ids = set(records.ids)
+        level = records
+        depth = 0
+        while level:
+            parent_ids = set(level.mapped(parent_field).ids)
+            if not parent_ids:
+                break
+            depth += 1
+            if depth > HIERARCHY_MAX_DEPTH:
+                self._raise_hierarchy_depth_error(parent_field)
+            level = self.search([("id", "in", list(parent_ids))])
+            for ancestor_id in level.ids:
+                if ancestor_id in seen_ids:
+                    continue
+                seen_ids.add(ancestor_id)
+                ancestor_ids.append(ancestor_id)
+        return ancestor_ids
+
+    def _raise_hierarchy_depth_error(self, parent_field):
+        """Report a parent chain that never reaches a root record.
+
+        :param parent_field: name of the ``many2one`` being walked
+        :raises UserError: always
+        """
+        error_message = _(
+            """
+Context: Resolve the parent chain of a hierarchy view search
+Database ID: %s
+Problem: Field %s of model %s is nested deeper than %s levels
+Solution: Break the parent loop in the data of model %s
+"""
+            % (
+                self.id,
+                parent_field,
+                self._name,
+                HIERARCHY_MAX_DEPTH,
+                self._name,
+            )
+        )
+        raise UserError(error_message)

--- a/ssi_web_hierarchy_view/static/src/js/hierarchy_controller.js
+++ b/ssi_web_hierarchy_view/static/src/js/hierarchy_controller.js
@@ -44,13 +44,15 @@ odoo.define("ssi_web_hierarchy_view.HierarchyController", function (require) {
 
         /**
          * Only the root level is paginated: children loaded by expanding a
-         * node are never counted or paged separately.
+         * node are never counted or paged separately. Search mode has no
+         * pager at all: what the server caps there is the number of
+         * matches, through the view's ``limit``, not a page of roots.
          *
          * @override
          * @private
          */
         _getPagingInfo: function (state) {
-            if (!state.rootCount) {
+            if (!state.rootCount || state.searchMode) {
                 return null;
             }
             return {
@@ -58,6 +60,56 @@ odoo.define("ssi_web_hierarchy_view.HierarchyController", function (require) {
                 limit: state.limit,
                 size: state.rootCount,
             };
+        },
+
+        /**
+         * @override
+         * @private
+         * @param {Object} state
+         * @returns {Promise}
+         */
+        _update: function (state) {
+            return this._super
+                .apply(this, arguments)
+                .then(() => this._warnIfSearchTruncated(state));
+        },
+
+        /**
+         * Warns once, when a search stops showing every match because the
+         * view's node limit was reached, and rearms the warning as soon as
+         * a later search fits again.
+         *
+         * @private
+         * @param {Object} state
+         */
+        _warnIfSearchTruncated: function (state) {
+            if (!state || !state.searchTruncated) {
+                this.searchTruncationWarned = false;
+                return;
+            }
+            if (this.searchTruncationWarned) {
+                return;
+            }
+            this.searchTruncationWarned = true;
+            this._notifyNodeLimit();
+        },
+
+        /**
+         * Tells the user that only part of the tree is on screen because
+         * the view's ``limit`` was reached. Shared by Expand All and by
+         * search mode, so both report the limit the same way.
+         *
+         * @private
+         */
+        _notifyNodeLimit: function () {
+            this.displayNotification({
+                type: "warning",
+                title: _t("Hierarchy view"),
+                message: _t(
+                    "Only part of the tree was expanded: this " +
+                        "view's node limit was reached."
+                ),
+            });
         },
 
         /**
@@ -107,14 +159,7 @@ odoo.define("ssi_web_hierarchy_view.HierarchyController", function (require) {
         _onExpandAllClicked: function () {
             this.model.expandAll().then((limitReached) => {
                 if (limitReached) {
-                    this.displayNotification({
-                        type: "warning",
-                        title: _t("Hierarchy view"),
-                        message: _t(
-                            "Only part of the tree was expanded: this " +
-                                "view's node limit was reached."
-                        ),
-                    });
+                    this._notifyNodeLimit();
                 }
                 return this._refresh();
             });

--- a/ssi_web_hierarchy_view/static/src/js/hierarchy_model.js
+++ b/ssi_web_hierarchy_view/static/src/js/hierarchy_model.js
@@ -19,6 +19,18 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
         return Array.isArray(value) ? value : [];
     }
 
+    /**
+     * @param {*} value a many2one value read by search_read/read, either
+     *      false or a [id, display_name] pair
+     * @returns {Number|Boolean} the id it carries, false when empty
+     */
+    function toId(value) {
+        if (Array.isArray(value)) {
+            return value.length ? value[0] : false;
+        }
+        return value || false;
+    }
+
     const HierarchyModel = AbstractModel.extend({
         /**
          * @override
@@ -30,6 +42,8 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
             this.rootCount = 0;
             this.offset = 0;
             this.limitReached = false;
+            this.searchMode = false;
+            this.searchTruncated = false;
         },
 
         /**
@@ -45,6 +59,8 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
                 nodeLimit: this.nodeLimit,
                 loadedCount: Object.keys(this.rows).length,
                 limitReached: this.limitReached,
+                searchMode: this.searchMode,
+                searchTruncated: this.searchTruncated,
             };
         },
 
@@ -59,10 +75,15 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
             this.defaultExpand = params.defaultExpand;
             this.nodeLimit = params.limit;
             this.domain = params.domain || [];
+            // The domain the view is loaded with belongs to the action,
+            // not to the search view: it is the baseline search mode is
+            // measured against, so that clearing every filter goes back
+            // to the full tree instead of staying in search mode forever.
+            this.baseDomain = this.domain.slice();
             this.context = params.context || {};
             this.rootLimit = ROOT_PAGE_SIZE;
             this.offset = 0;
-            return this._fetchRoots().then(() => this._applyDefaultExpand());
+            return this._fetch();
         },
 
         /**
@@ -85,7 +106,7 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
             if (options.limit !== undefined) {
                 this.rootLimit = options.limit;
             }
-            return this._fetchRoots().then(() => this._applyDefaultExpand());
+            return this._fetch();
         },
 
         // --------------------------------------------------------------------
@@ -160,6 +181,124 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
         // --------------------------------------------------------------------
 
         /**
+         * Builds the tree the current domain asks for: the search result
+         * tree while a search view filter is active, the full lazy tree
+         * otherwise.
+         *
+         * @private
+         * @returns {Promise}
+         */
+        _fetch: function () {
+            if (this._isSearchMode()) {
+                return this._fetchSearchTree();
+            }
+            return this._fetchRoots().then(() => this._applyDefaultExpand());
+        },
+
+        /**
+         * Search mode needs ``parent_field``: without it the parent chain
+         * of a match cannot be walked upwards at all, so the view falls
+         * back to flat filtering (see README). It also needs the search
+         * view to have actually added something to the action's own
+         * domain, otherwise every load would be a search.
+         *
+         * @private
+         * @returns {Boolean}
+         */
+        _isSearchMode: function () {
+            if (!this.parentField) {
+                return false;
+            }
+            return (
+                JSON.stringify(this.domain) !== JSON.stringify(this.baseDomain || [])
+            );
+        },
+
+        /**
+         * Loads the whole search result tree in two queries: one asking
+         * the server for the matching ids plus the ids of their
+         * ancestors, one reading the fields of that union in ``_order``.
+         *
+         * @private
+         * @returns {Promise}
+         */
+        _fetchSearchTree: function () {
+            return this._rpc({
+                model: this.modelName,
+                method: "hierarchy_search_ancestors",
+                args: [this.domain, this.parentField],
+                kwargs: {limit: this.nodeLimit},
+                context: this.context,
+            }).then((result) => {
+                this.searchMode = true;
+                this.searchTruncated = Boolean(result.truncated);
+                this.limitReached = false;
+                this.offset = 0;
+                const ids = result.matches.concat(result.ancestors);
+                if (!ids.length) {
+                    this.rows = {};
+                    this.rootKeys = [];
+                    this.rootCount = 0;
+                    return Promise.resolve();
+                }
+                return this._rpc({
+                    model: this.modelName,
+                    method: "search_read",
+                    kwargs: {
+                        domain: [["id", "in", ids]],
+                        fields: this.fieldNames,
+                        context: this.context,
+                    },
+                }).then((records) => this._buildSearchTree(records, result.matches));
+            });
+        },
+
+        /**
+         * Turns the flat search result into a tree: a record whose parent
+         * is part of the result becomes its child, every other record
+         * becomes a root. Every node holding children is registered as
+         * already loaded and already open, so the chain leading to a
+         * match is visible without the user opening anything and without
+         * ``default_expand`` having any say while the filter is active.
+         *
+         * @private
+         * @param {Array} records the union of the matches and their
+         *      ancestors, ordered by the model ``_order``
+         * @param {Array} matchIds ids of the records matching the domain
+         */
+        _buildSearchTree: function (records, matchIds) {
+            const matched = new Set(matchIds);
+            const loaded = new Set(records.map((record) => record.id));
+            const childrenOf = {};
+            const roots = [];
+            for (const record of records) {
+                const parentId = toId(record[this.parentField]);
+                if (parentId && loaded.has(parentId)) {
+                    childrenOf[parentId] = childrenOf[parentId] || [];
+                    childrenOf[parentId].push(record);
+                } else {
+                    roots.push(record);
+                }
+            }
+            this.rows = {};
+            const register = (record, parentKey, level) => {
+                const key = this._registerRow(record, parentKey, level);
+                const row = this.rows[key];
+                const children = childrenOf[record.id] || [];
+                row.isMatch = matched.has(record.id);
+                row.hasChildren = children.length > 0;
+                row.isLoaded = true;
+                row.isOpen = children.length > 0;
+                row.childKeys = children.map((child) =>
+                    register(child, key, level + 1)
+                );
+                return key;
+            };
+            this.rootKeys = roots.map((record) => register(record, false, 0));
+            this.rootCount = this.rootKeys.length;
+        },
+
+        /**
          * Opens a node, loading its children first if they were never
          * fetched. Refuses to grow past ``nodeLimit`` nodes in memory.
          *
@@ -208,6 +347,8 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
             ]).then(([count, records]) => {
                 this.rows = {};
                 this.limitReached = false;
+                this.searchMode = false;
+                this.searchTruncated = false;
                 this.rootCount = count;
                 this.rootKeys = records.map((record) =>
                     this._registerRow(record, false, 0)
@@ -251,6 +392,9 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
                 isOpen: false,
                 isLoaded: false,
                 childKeys: null,
+                // Only meaningful in search mode, where a row is either a
+                // match or one of the ancestors dragged along with it.
+                isMatch: false,
             };
             return key;
         },

--- a/ssi_web_hierarchy_view/static/src/js/hierarchy_renderer.js
+++ b/ssi_web_hierarchy_view/static/src/js/hierarchy_renderer.js
@@ -115,6 +115,21 @@ odoo.define("ssi_web_hierarchy_view.HierarchyRenderer", function (require) {
         },
 
         /**
+         * Tells a row matching the active filter apart from a row only
+         * present because it is an ancestor of a match. Returns nothing
+         * outside search mode: in the full tree every row is equal.
+         *
+         * @param {Object} row
+         * @returns {String} the extra class of the row element
+         */
+        rowClass: function (row) {
+            if (!this.state.searchMode) {
+                return "";
+            }
+            return row.isMatch ? "o_hierarchy_match" : "o_hierarchy_context";
+        },
+
+        /**
          * @param {Object} row
          * @returns {String} the fontawesome class of the expand/collapse
          *      toggle

--- a/ssi_web_hierarchy_view/static/src/scss/hierarchy.scss
+++ b/ssi_web_hierarchy_view/static/src/scss/hierarchy.scss
@@ -28,6 +28,29 @@
     }
 }
 
+// While a search view filter is active, a row is either a record that
+// matched the filter or one of the ancestors dragged along to keep the
+// match reachable. Only the former is highlighted.
+.o_hierarchy_row.o_hierarchy_match {
+    background-color: #fff3cd;
+
+    &:hover {
+        background-color: #ffeeba;
+    }
+
+    .o_hierarchy_label {
+        font-weight: bold;
+    }
+}
+
+.o_hierarchy_row.o_hierarchy_context {
+    color: #6c757d;
+
+    .o_hierarchy_label {
+        font-style: italic;
+    }
+}
+
 .o_hierarchy_cell_main {
     display: flex;
     align-items: center;

--- a/ssi_web_hierarchy_view/static/src/xml/hierarchy.xml
+++ b/ssi_web_hierarchy_view/static/src/xml/hierarchy.xml
@@ -32,7 +32,10 @@
             </thead>
             <tbody>
                 <t t-foreach="rows" t-as="row">
-                    <tr class="o_hierarchy_row" t-att-data-key="row.key">
+                    <tr
+                        t-attf-class="o_hierarchy_row #{widget.rowClass(row)}"
+                        t-att-data-key="row.key"
+                    >
                         <td class="o_hierarchy_cell_main">
                             <span
                                 class="o_hierarchy_indent"

--- a/ssi_web_hierarchy_view/tests/test_data_ssi_web_hierarchy_view.yaml
+++ b/ssi_web_hierarchy_view/tests/test_data_ssi_web_hierarchy_view.yaml
@@ -226,6 +226,32 @@ scenarios:
           arch: |
             <hierarchy parent_field="no_such_field_at_all" />
 
+  - name: "ssi_web_hierarchy_view - parent_field survives the search feature"
+    steps:
+      - step: "Create a hierarchy view whose parent_field drives the search"
+        action: "create"
+        model: "ir.ui.view"
+        save_as: "view"
+        values:
+          name: "Partner Hierarchy Searchable"
+          model: "res.partner"
+          type: "hierarchy"
+          arch: |
+            <hierarchy parent_field="parent_id" limit="500">
+                <field name="name" />
+            </hierarchy>
+      - step: "Assert parent_field is still stored in the validated arch"
+        action: "assert"
+        target: "view"
+        asserts:
+          type:
+            type: "value"
+            expected: "hierarchy"
+          arch_db:
+            type: "value"
+            operator: "contains"
+            expected: 'parent_field="parent_id"'
+
   - name: "ssi_web_hierarchy_view - Action view_mode accepts hierarchy"
     steps:
       - step: "Create a hierarchy view on res.partner"

--- a/ssi_web_hierarchy_view/tests/test_ssi_web_hierarchy_view.py
+++ b/ssi_web_hierarchy_view/tests/test_ssi_web_hierarchy_view.py
@@ -4,12 +4,153 @@
 
 from odoo_yaml_test import YamlTransactionCase
 
+from odoo.exceptions import UserError
 from odoo.tests import tagged
 
 
 @tagged("post_install", "-at_install")
 class TestSsiWebHierarchyView(YamlTransactionCase):
-    """Runs the ``hierarchy`` view type arch validation scenarios."""
+    """Covers the ``hierarchy`` view type arch validation and the search.
+
+    The arch validation scenarios live in the YAML file; the hierarchical
+    search is asserted here because what is under test is the value
+    ``hierarchy_search_ancestors`` returns.
+    """
+
+    def _create_partner_chain(self, prefix):
+        """Create a three level ``res.partner`` chain.
+
+        :param prefix: prefix made unique per test, so that the domains
+            of one test never match the records of another
+        :return: tuple of the grandparent, the parent and the child
+        """
+        partner_model = self.env["res.partner"]
+        grandparent = partner_model.create({"name": "%s Grandparent" % prefix})
+        parent = partner_model.create(
+            {"name": "%s Parent" % prefix, "parent_id": grandparent.id}
+        )
+        child = partner_model.create(
+            {"name": "%s Child" % prefix, "parent_id": parent.id}
+        )
+        return grandparent, parent, child
 
     def test_ssi_web_hierarchy_view(self):
+        """Run the ``hierarchy`` view type arch validation scenarios."""
         self.run_yaml_scenario("test_data_ssi_web_hierarchy_view.yaml")
+
+    def test_search_ancestors_of_a_grandchild(self):
+        """Assert the parent chain returned for a deep match.
+
+        Pure Python — trigger P1 (L-01: the ``call`` action discards the
+        return value of a method, and L-02 only lets an assert reach a
+        field of a record, never a returned dict).
+        """
+        grandparent, parent, child = self._create_partner_chain("SSIWHV Deep")
+        result = self.env["res.partner"].hierarchy_search_ancestors(
+            [("name", "=", "SSIWHV Deep Child")], "parent_id"
+        )
+        self.assertEqual(result["matches"], [child.id])
+        self.assertEqual(set(result["ancestors"]), {parent.id, grandparent.id})
+        self.assertFalse(result["truncated"])
+
+    def test_search_ancestors_are_not_duplicated(self):
+        """Assert two sibling matches share their ancestors only once.
+
+        Pure Python — trigger P1 (L-01: the ``call`` action discards the
+        return value of a method, so YAML cannot see the list at all).
+        """
+        grandparent, parent, child = self._create_partner_chain("SSIWHV Sibling")
+        sibling = self.env["res.partner"].create(
+            {"name": "SSIWHV Sibling Child Two", "parent_id": parent.id}
+        )
+        result = self.env["res.partner"].hierarchy_search_ancestors(
+            [("name", "like", "SSIWHV Sibling Child")], "parent_id"
+        )
+        self.assertEqual(set(result["matches"]), {child.id, sibling.id})
+        self.assertEqual(set(result["ancestors"]), {parent.id, grandparent.id})
+        self.assertEqual(len(result["ancestors"]), 2)
+
+    def test_search_ancestors_of_a_root_match(self):
+        """Assert a match without any parent reports no ancestor.
+
+        Pure Python — trigger P1 (L-01: the ``call`` action discards the
+        return value of a method, so the empty list cannot be asserted
+        in YAML).
+        """
+        root = self.env["res.partner"].create({"name": "SSIWHV Root Only"})
+        result = self.env["res.partner"].hierarchy_search_ancestors(
+            [("name", "=", "SSIWHV Root Only")], "parent_id"
+        )
+        self.assertEqual(result["matches"], [root.id])
+        self.assertEqual(result["ancestors"], [])
+
+    def test_search_ancestors_reports_a_truncated_result(self):
+        """Assert ``truncated`` follows the ``limit`` given by the view.
+
+        Pure Python — trigger P1 (L-01: the ``call`` action discards the
+        return value of a method, so the flag cannot be asserted in
+        YAML).
+        """
+        self._create_partner_chain("SSIWHV Limit")
+        partner_model = self.env["res.partner"]
+        result = partner_model.hierarchy_search_ancestors(
+            [("name", "like", "SSIWHV Limit")], "parent_id", limit=2
+        )
+        self.assertEqual(len(result["matches"]), 2)
+        self.assertTrue(result["truncated"])
+
+        result = partner_model.hierarchy_search_ancestors(
+            [("name", "like", "SSIWHV Limit")], "parent_id", limit=5
+        )
+        self.assertEqual(len(result["matches"]), 3)
+        self.assertFalse(result["truncated"])
+
+    def test_search_ancestors_rejects_an_unknown_parent_field(self):
+        """Reject a ``parent_field`` naming a field that does not exist.
+
+        Pure Python — trigger P1 (L-01: the method is called for its
+        return value, and L-02 keeps YAML asserts on record fields, so
+        the guard cannot be reached declaratively).
+        """
+        with self.assertRaises(UserError) as error:
+            self.env["res.partner"].hierarchy_search_ancestors(
+                [], "no_such_field_at_all"
+            )
+        self.assertIn("no_such_field_at_all", str(error.exception))
+        self.assertIn("does not exist", str(error.exception))
+
+    def test_search_ancestors_rejects_a_parent_field_that_is_not_m2o(self):
+        """Reject a ``parent_field`` that is not a many2one to the model.
+
+        Pure Python — trigger P1 (L-01: the method is called for its
+        return value, and L-02 keeps YAML asserts on record fields, so
+        the guard cannot be reached declaratively).
+        """
+        with self.assertRaises(UserError) as error:
+            self.env["res.partner"].hierarchy_search_ancestors([], "name")
+        self.assertIn("is not a many2one field", str(error.exception))
+
+    def test_search_ancestors_rejects_cyclic_data(self):
+        """Reject a parent chain that never reaches a root record.
+
+        Pure Python — trigger P1 (L-01: the method is called for its
+        return value) combined with the raw SQL needed to produce the
+        cycle: ``res.partner._check_parent_id`` makes a cycle
+        unwritable through the ORM, and YAML has no way to bypass a
+        constraint (L-02).
+        """
+        root = self.env["res.partner"].create({"name": "SSIWHV Cycle Root"})
+        child = self.env["res.partner"].create(
+            {"name": "SSIWHV Cycle Child", "parent_id": root.id}
+        )
+        self.env["res.partner"].flush()
+        self.env.cr.execute(
+            "UPDATE res_partner SET parent_id = %s WHERE id = %s",
+            (child.id, root.id),
+        )
+        self.env["res.partner"].invalidate_cache()
+        with self.assertRaises(UserError) as error:
+            self.env["res.partner"].hierarchy_search_ancestors(
+                [("id", "=", child.id)], "parent_id"
+            )
+        self.assertIn("nested deeper than 64 levels", str(error.exception))


### PR DESCRIPTION
Filter dari search view kini menampilkan setiap record yang cocok pada
kedalaman berapa pun di dalam pohon, beserta seluruh rantai induknya yang
otomatis terbuka.

## Perubahan

* **`models/base.py` (baru)** — method `hierarchy_search_ancestors(domain,
  parent_field, limit=None)` pada model `base`. Kembalian: `matches` (id
  record yang cocok, terurut `_order`), `ancestors` (id leluhur yang tidak
  ikut cocok domain), `truncated`. Rantai induk dihitung server-side dalam
  satu panggilan, **tanpa `sudo()`** — leluhur yang tak boleh dibaca user
  dibuang senyap dan anaknya naik menjadi akar. Rantai lebih dari **64
  tingkat** dianggap data siklik dan memicu `UserError` berformat SSI.
* **`hierarchy_model.js`** — mode pencarian aktif bila `parent_field` ada di
  arch dan search view menambah klausa di atas domain aksi. Pohon hasil
  pencarian dibangun dari dua query, seluruh rantai induk ditandai
  `isLoaded`/`isOpen`, sehingga `default_expand` diabaikan selama filter
  aktif dan berlaku lagi begitu filter dibersihkan.
* **`hierarchy_renderer.js` / `hierarchy.xml` / `hierarchy.scss`** — node
  yang cocok memakai kelas `o_hierarchy_match` dan disorot; node yang hadir
  hanya sebagai leluhur memakai `o_hierarchy_context` dan tidak disorot.
* **`hierarchy_controller.js`** — notifikasi batas node dipakai bersama oleh
  Expand All dan hasil pencarian yang terpotong `limit`; pager disembunyikan
  pada mode pencarian karena yang dibatasi adalah jumlah match, bukan
  halaman akar.
* **`README.rst`** — bagian *Searching the hierarchy* + batasan bahwa view
  yang hanya punya `child_field` turun ke penyaringan datar.

## Test

* Python murni (pemicu **P1**, L-01/L-02 — yang diuji adalah nilai balik
  method): rantai induk cucu, leluhur tanpa duplikat untuk dua cucu
  bersaudara, match akar tanpa leluhur, `truncated` mengikuti `limit`,
  `parent_field` tak ada / bukan many2one → `UserError`, data siklik →
  `UserError` batas rekursi.
* Skenario `odoo-yaml-test`: regresi validasi arch `hierarchy` dengan
  `parent_field` tersimpan.

Closes #80