### PR TITLE
[UPD] ssi_web_hierarchy_view: decoration, sticky header, dan navigasi keyboard

### DIFF
--- a/ssi_web_hierarchy_view/README.rst
+++ b/ssi_web_hierarchy_view/README.rst
@@ -19,9 +19,9 @@ organizational structure, ...) can be browsed as a tree instead of only as a
 flat list or through a ``child_of`` filter.
 
 This iteration is **read only**: dragging a row to reparent it, inline edit
-and ``groupBy`` are out of scope. ``decoration-*``, a sticky header beyond
-the column headers, keyboard navigation and numeric column aggregation
-(``sum=``) are not implemented either.
+and ``groupBy`` are out of scope. Per column ``decoration-*``
+(``<field decoration-…>``), user resizable or hideable columns and numeric
+column aggregation (``sum=``) are not implemented either.
 
 Usage
 =====
@@ -74,6 +74,70 @@ The first ``<field>`` child of the ``hierarchy`` tag is the hierarchy column:
 it carries the indentation and the expand/collapse toggle. Every other
 ``<field>`` is a plain column. Without any ``<field>`` at all, the hierarchy
 column falls back to ``display_name``.
+
+Row decorations
+---------------
+
+A row is coloured by the ``decoration-*`` attributes of the ``hierarchy``
+tag, the same way a list view colours its own rows. The value of such an
+attribute is a Python expression evaluated in the browser against the values
+of the row::
+
+    <hierarchy parent_field="parent_id" decoration-danger="not active">
+        <field name="name" />
+    </hierarchy>
+
+Seven suffixes are supported, exactly the ones ``ssi_web_gantt`` supports:
+``danger``, ``warning``, ``info``, ``success``, ``primary``, ``secondary``
+and ``muted``. Anything else — ``decoration-mantap``, a misspelt
+``decoration-sucess`` — is **rejected when the view is saved** rather than
+ignored silently, and so is an expression that is not valid Python.
+
+* A row a decoration lights up on carries the class
+  ``o_hierarchy_row_<suffix>``, so a database may restyle a decoration
+  without touching this module.
+* Several decorations may light up on the same row. They are applied in the
+  order of the list above, so the last one that lights up is the colour
+  actually seen.
+* A field read by an expression is fetched even when it is no column of the
+  tree: the view registers it server side, which is also what makes an
+  expression naming a field that does not exist fail at save time instead of
+  in the browser.
+* The expression is evaluated against the row's own values plus ``uid``,
+  ``today`` and ``now``.
+
+Sticky header and keyboard navigation
+-------------------------------------
+
+The column headers stay visible while a long tree is scrolled. This is
+plain CSS (``position: sticky`` on the header cells), so there is no scroll
+listener and no position arithmetic anywhere.
+
+The tree is fully reachable from the keyboard. The focus is on rows, never on
+cells, and only one row at a time is reachable with ``Tab`` (a roving
+``tabindex``), so ``Tab`` steps over the tree instead of walking through
+every single row.
+
+``ArrowDown`` / ``ArrowUp``
+  Move to the next/previous visible row.
+
+``ArrowRight``
+  Open a closed node; move to its first child when it is already open.
+
+``ArrowLeft``
+  Close an open node; move to its parent when it is already closed.
+
+``Enter``
+  Open the form view of the focused row.
+
+``Home`` / ``End``
+  Move to the first/last visible row.
+
+Moving the focus never changes the page of the pager, and the expansion
+state is only ever changed by ``ArrowLeft``/``ArrowRight``. The tree exposes
+``role="tree"``, every row ``role="treeitem"`` with ``aria-level``,
+``aria-setsize``/``aria-posinset`` and, on a node that has children,
+``aria-expanded``.
 
 Other attributes
 ----------------
@@ -154,6 +218,8 @@ Example
                 parent_field="parent_id"
                 child_field="child_ids"
                 default_expand="1"
+                decoration-muted="not active"
+                decoration-info="is_company"
             >
                 <field name="name" />
                 <field name="email" />
@@ -171,8 +237,10 @@ Known limitations
 * No ``groupBy``: grouping records would collide with the hierarchy itself.
 * No client-side search inside the already loaded tree: filtering always
   goes back to the server.
-* No ``decoration-*`` and no sticky header beyond the column headers.
-* No keyboard navigation.
+* ``decoration-*`` is per row only: ``<field decoration-…>``, which colours
+  a single cell in a list view, is not supported.
+* No user resizable or hideable columns, and no preference remembering
+  either.
 * No numeric column aggregation (``sum=``).
 
 Installation

--- a/ssi_web_hierarchy_view/models/ir_ui_view.py
+++ b/ssi_web_hierarchy_view/models/ir_ui_view.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import _, fields, models
+from odoo.tools.view_validation import get_variable_names
 
 # Arch attributes naming a field of the view's own model. Both are
 # registered on the name manager exactly like a <field> child, so the
@@ -11,6 +12,23 @@ from odoo import _, fields, models
 FIELD_ATTRIBUTES = [
     "child_field",
     "parent_field",
+]
+
+# Prefix of the row decoration attributes, the same one a list view uses.
+DECORATION_PREFIX = "decoration-"
+
+# Decoration suffixes the hierarchy tag accepts, exactly the ones
+# ssi_web_gantt accepts. The order is the order the row classes are applied
+# in, so a suffix listed later wins over an earlier one whenever several
+# decorations light up on the same row.
+DECORATION_SUFFIXES = [
+    "danger",
+    "warning",
+    "info",
+    "success",
+    "primary",
+    "secondary",
+    "muted",
 ]
 
 
@@ -36,7 +54,9 @@ class IrUiView(models.Model):
         so both are registered on the name manager exactly like a
         ``<field>`` child: the generic field-existence check then rejects
         an arch that points at a field which does not exist, without any
-        extra code here.
+        extra code here. The fields read by a ``decoration-*`` expression
+        are registered the same way, so that they are fetched by the
+        browser even when they are no column of the tree.
 
         :param node: the ``<hierarchy>`` arch element
         :param name_manager: the view's ``NameManager``
@@ -47,10 +67,127 @@ class IrUiView(models.Model):
             if value:
                 name_manager.has_field(value, {})
 
+        self._register_hierarchy_decoration_fields(node, name_manager)
+
         if name_manager.validate:
             self._validate_hierarchy_fields(node, name_manager.Model)
+            self._validate_hierarchy_decorations(node)
 
         node_info["editable"] = False
+
+    def _hierarchy_decorations(self, node):
+        """Return the ``decoration-*`` attributes of the hierarchy tag.
+
+        :param node: the ``<hierarchy>`` arch element
+        :return: list of ``(suffix, expression)`` tuples, in arch order,
+            the suffix being whatever follows ``decoration-`` and not
+            necessarily a supported one
+        """
+        decorations = []
+        for attribute, expression in node.items():
+            if attribute.startswith(DECORATION_PREFIX):
+                suffix = attribute[len(DECORATION_PREFIX) :]
+                decorations.append((suffix, expression))
+        return decorations
+
+    def _register_hierarchy_decoration_fields(self, node, name_manager):
+        """Register every field read by a ``decoration-*`` expression.
+
+        A field only used by a decoration expression is no column of the
+        tree, so nothing else declares it. Registering it here serves two
+        purposes at once: the generic attribute validation of
+        ``ir.ui.view`` requires every name a ``decoration-*`` expression
+        reads to be a field available in the view, and
+        ``fields_view_get`` reports exactly the registered fields, which
+        is what the browser fetches.
+
+        An expression that is not valid Python is skipped silently here
+        and reported by :meth:`_validate_hierarchy_decorations`, the only
+        place that is allowed to raise.
+
+        :param node: the ``<hierarchy>`` arch element
+        :param name_manager: the view's ``NameManager``
+        """
+        for suffix, expression in self._hierarchy_decorations(node):
+            if suffix not in DECORATION_SUFFIXES:
+                continue
+            for field_name in self._hierarchy_decoration_field_names(expression):
+                name_manager.has_field(field_name, {})
+
+    def _hierarchy_decoration_field_names(self, expression):
+        """Return the field names a decoration expression reads.
+
+        Symbols of the evaluation context itself (``uid``, ``context``,
+        ``datetime``, ...) are left out by the very same helper the list
+        view relies on. A dotted name is left out too: it is no field of
+        the model, and the generic attribute validation already rejects
+        it as a composed field.
+
+        :param expression: value of a ``decoration-*`` attribute
+        :return: sorted list of field names, empty when the expression is
+            not valid Python
+        """
+        try:
+            names = get_variable_names(expression)
+        except SyntaxError:
+            return []
+        return sorted(name for name in names if "." not in name)
+
+    def _validate_hierarchy_decorations(self, node):
+        """Validate the ``decoration-*`` attributes of the hierarchy tag.
+
+        Only the suffixes of ``DECORATION_SUFFIXES`` are accepted, and
+        the expression of each of them has to be valid Python. An unknown
+        suffix is a typo that would otherwise colour nothing at all, and
+        a broken expression would only ever fail in the browser, long
+        after the view was saved.
+
+        Which fields an expression may read is not checked here: the
+        generic attribute validation of ``ir.ui.view`` already requires
+        every name it reads to be a field available in the view.
+
+        :param node: the ``<hierarchy>`` arch element
+        """
+        for suffix, expression in self._hierarchy_decorations(node):
+            if suffix not in DECORATION_SUFFIXES:
+                self._raise_hierarchy_decoration_suffix_error(suffix)
+            self._validate_hierarchy_decoration_expression(suffix, expression)
+
+    def _validate_hierarchy_decoration_expression(self, suffix, expression):
+        """Reject a decoration expression that is not valid Python.
+
+        :param suffix: the supported suffix the expression belongs to
+        :param expression: value of the ``decoration-*`` attribute
+        """
+        try:
+            get_variable_names(expression)
+        except SyntaxError:
+            error_message = _(
+                """
+Context: Validate hierarchy view architecture
+Database ID: %s
+Problem: Attribute decoration-%s is not a valid Python expression: %s
+Solution: Write the value of decoration-%s as a Python expression
+"""
+                % (self.id, suffix, expression, suffix)
+            )
+            self.handle_view_error(error_message)
+
+    def _raise_hierarchy_decoration_suffix_error(self, suffix):
+        """Reject a ``decoration-*`` attribute with an unsupported suffix.
+
+        :param suffix: whatever followed ``decoration-`` in the arch
+        """
+        error_message = _(
+            """
+Context: Validate hierarchy view architecture
+Database ID: %s
+Problem: Attribute decoration-%s is not a supported row decoration
+Solution: Use one of the supported decorations: %s
+"""
+            % (self.id, suffix, ", ".join(DECORATION_SUFFIXES))
+        )
+        self.handle_view_error(error_message)
 
     def _validate_hierarchy_fields(self, node, model):
         """Validate the ``child_field``/``parent_field`` attributes.

--- a/ssi_web_hierarchy_view/static/src/js/hierarchy_renderer.js
+++ b/ssi_web_hierarchy_view/static/src/js/hierarchy_renderer.js
@@ -1,3 +1,4 @@
+/* global py */
 /* Copyright 2026 OpenSynergy Indonesia
  * Copyright 2026 PT. Simetri Sinergi Indonesia
  * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
@@ -8,16 +9,51 @@ odoo.define("ssi_web_hierarchy_view.HierarchyRenderer", function (require) {
     const AbstractRenderer = require("web.AbstractRenderer");
     const core = require("web.core");
     const field_utils = require("web.field_utils");
+    const session = require("web.session");
 
     const qweb = core.qweb;
 
     // Horizontal indentation added per hierarchy level, in pixels.
     const INDENT_PX = 20;
 
+    // Row decorations, in the order their classes are applied: a decoration
+    // listed later wins over an earlier one whenever several of them light
+    // up on the same row. The stylesheet declares them in this very order.
+    const DECORATIONS = [
+        "danger",
+        "warning",
+        "info",
+        "success",
+        "primary",
+        "secondary",
+        "muted",
+    ];
+
+    // Keys the tree answers to. Anything else is left to the browser, so
+    // that Tab, Shift+Tab and shortcuts keep working inside the view.
+    const KEY_DOWN = "ArrowDown";
+    const KEY_UP = "ArrowUp";
+    const KEY_RIGHT = "ArrowRight";
+    const KEY_LEFT = "ArrowLeft";
+    const KEY_ENTER = "Enter";
+    const KEY_HOME = "Home";
+    const KEY_END = "End";
+    const HANDLED_KEYS = [
+        KEY_DOWN,
+        KEY_UP,
+        KEY_RIGHT,
+        KEY_LEFT,
+        KEY_ENTER,
+        KEY_HOME,
+        KEY_END,
+    ];
+
     const HierarchyRenderer = AbstractRenderer.extend({
         events: _.extend({}, AbstractRenderer.prototype.events, {
             "click .o_hierarchy_toggle": "_onToggleClick",
             "click .o_hierarchy_row": "_onRowClick",
+            "keydown .o_hierarchy_row": "_onRowKeydown",
+            "focusin .o_hierarchy_row": "_onRowFocusIn",
         }),
 
         /**
@@ -27,6 +63,13 @@ odoo.define("ssi_web_hierarchy_view.HierarchyRenderer", function (require) {
             this._super.apply(this, arguments);
             this.columns = params.columns;
             this.fields = params.fields;
+            this.decorations = params.decorations || {};
+            // The rows actually drawn, in the order they are drawn: what
+            // ArrowUp/ArrowDown and Home/End walk through.
+            this.visibleRows = [];
+            // Roving tabindex: the one row reachable with Tab, so that Tab
+            // steps over the whole tree instead of through every row.
+            this.focusedKey = false;
         },
 
         // --------------------------------------------------------------------
@@ -36,20 +79,36 @@ odoo.define("ssi_web_hierarchy_view.HierarchyRenderer", function (require) {
         /**
          * Preserves the scroll position of the table across a re-render, so
          * that opening or closing a distant node does not jump the viewport
-         * back to the top.
+         * back to the top, together with the keyboard focus: opening a node
+         * with ArrowRight has to leave the focus on the very row that was
+         * opened.
          *
          * @override
          */
         getLocalState: function () {
-            return {scrollTop: this.el.scrollTop};
+            return {
+                scrollTop: this.el.scrollTop,
+                focusedKey: this.focusedKey,
+                // Only a row that really held the browser focus is focused
+                // again after the re-render: re-rendering because of a
+                // mouse click must not steal the focus from elsewhere.
+                hasFocus: this.$(".o_hierarchy_row:focus").length > 0,
+            };
         },
 
         /**
          * @override
          */
         setLocalState: function (localState) {
-            if (localState) {
-                this.el.scrollTop = localState.scrollTop || 0;
+            if (!localState) {
+                return;
+            }
+            this.el.scrollTop = localState.scrollTop || 0;
+            if (!localState.focusedKey) {
+                return;
+            }
+            if (localState.hasFocus) {
+                this._focusRow(localState.focusedKey);
             }
         },
 
@@ -62,6 +121,8 @@ odoo.define("ssi_web_hierarchy_view.HierarchyRenderer", function (require) {
          */
         _renderView: function () {
             const rows = this._visibleRows();
+            this.visibleRows = rows;
+            this.focusedKey = this._normalizeFocusedKey(rows);
             this.$el.empty().addClass("o_hierarchy_view");
             if (!this.state.rootCount) {
                 this.$el.append(qweb.render("ssi_web_hierarchy_view.Empty"));
@@ -104,6 +165,26 @@ odoo.define("ssi_web_hierarchy_view.HierarchyRenderer", function (require) {
         },
 
         /**
+         * The row the roving tabindex belongs to. The row focused last as
+         * long as it is still drawn, the first row otherwise, so that Tab
+         * always reaches the tree at a meaningful place — including right
+         * after a node was collapsed away under the focus.
+         *
+         * @private
+         * @param {Array} rows the rows about to be drawn
+         * @returns {String|Boolean}
+         */
+        _normalizeFocusedKey: function (rows) {
+            if (!rows.length) {
+                return false;
+            }
+            if (this.focusedKey && rows.some((row) => row.key === this.focusedKey)) {
+                return this.focusedKey;
+            }
+            return rows[0].key;
+        },
+
+        /**
          * The indentation width of one row, used inline in the QWeb
          * template since SCSS cannot depend on a dynamic level.
          *
@@ -115,18 +196,123 @@ odoo.define("ssi_web_hierarchy_view.HierarchyRenderer", function (require) {
         },
 
         /**
-         * Tells a row matching the active filter apart from a row only
-         * present because it is an ancestor of a match. Returns nothing
-         * outside search mode: in the full tree every row is equal.
+         * The extra classes of a row: which decorations of the arch light
+         * up on it and, in search mode only, whether it matched the filter
+         * itself or is one of the ancestors dragged along with a match.
          *
          * @param {Object} row
-         * @returns {String} the extra class of the row element
+         * @returns {String} the extra classes of the row element
          */
         rowClass: function (row) {
-            if (!this.state.searchMode) {
-                return "";
+            const classes = [];
+            if (this.state.searchMode) {
+                classes.push(row.isMatch ? "o_hierarchy_match" : "o_hierarchy_context");
             }
-            return row.isMatch ? "o_hierarchy_match" : "o_hierarchy_context";
+            for (const decoration of DECORATIONS) {
+                if (this._evalDecoration(decoration, row)) {
+                    classes.push("o_hierarchy_row_" + decoration);
+                }
+            }
+            return classes.join(" ");
+        },
+
+        /**
+         * @private
+         * @param {String} decoration
+         * @param {Object} row
+         * @returns {Boolean} whether the decoration lights up on that row
+         */
+        _evalDecoration: function (decoration, row) {
+            const expression = this.decorations[decoration];
+            if (!expression) {
+                return false;
+            }
+            return py.PY_isTrue(py.evaluate(expression, this._evalContext(row.data)));
+        },
+
+        /**
+         * @private
+         * @param {Object} record the raw values of one row
+         * @returns {Object} the context a decoration expression is
+         *      evaluated in
+         */
+        _evalContext: function (record) {
+            const context = _.extend({}, session.user_context, {
+                uid: session.uid,
+                today: moment().format("YYYY-MM-DD"),
+                now: moment().format("YYYY-MM-DD HH:mm:ss"),
+            });
+            for (const name of Object.keys(record)) {
+                const field = this.fields[name];
+                const value = record[name];
+                if (field && field.type === "many2one" && Array.isArray(value)) {
+                    context[name] = value.length ? value[0] : false;
+                } else {
+                    context[name] = value;
+                }
+            }
+            return context;
+        },
+
+        /**
+         * @param {Object} row
+         * @returns {Number} the ARIA level of a row, one based
+         */
+        ariaLevel: function (row) {
+            return row.level + 1;
+        },
+
+        /**
+         * @param {Object} row
+         * @returns {String|undefined} ``aria-expanded`` of a row, left out
+         *      entirely on a leaf: a node without children is neither open
+         *      nor closed
+         */
+        ariaExpanded: function (row) {
+            if (!row.hasChildren) {
+                return undefined;
+            }
+            return row.isOpen ? "true" : "false";
+        },
+
+        /**
+         * @param {Object} row
+         * @returns {Number} how many siblings the row belongs to
+         */
+        ariaSetSize: function (row) {
+            return this._siblingKeys(row).length || 1;
+        },
+
+        /**
+         * @param {Object} row
+         * @returns {Number} the position of the row among its siblings, one
+         *      based
+         */
+        ariaPosInSet: function (row) {
+            const index = this._siblingKeys(row).indexOf(row.key);
+            return index === -1 ? 1 : index + 1;
+        },
+
+        /**
+         * @param {Object} row
+         * @returns {String} ``0`` on the one row Tab reaches, ``-1`` on
+         *      every other one
+         */
+        rowTabIndex: function (row) {
+            return row.key === this.focusedKey ? "0" : "-1";
+        },
+
+        /**
+         * @private
+         * @param {Object} row
+         * @returns {Array} the keys of the row's own level, itself included
+         */
+        _siblingKeys: function (row) {
+            const parent = row.parentKey ? this.state.rows[row.parentKey] : false;
+            if (parent) {
+                return parent.childKeys || [];
+            }
+            return this.state.rootKeys;
         },
 
         /**
@@ -173,6 +359,102 @@ odoo.define("ssi_web_hierarchy_view.HierarchyRenderer", function (require) {
             return value === false || value === undefined ? "" : String(value);
         },
 
+        /**
+         * @private
+         * @param {String} rowKey
+         * @returns {jQuery} the row element of a key, empty when that row
+         *      is not drawn
+         */
+        _rowElement: function (rowKey) {
+            return this.$(".o_hierarchy_row[data-key='" + rowKey + "']");
+        },
+
+        /**
+         * Moves the keyboard focus to a row and hands it the roving
+         * tabindex. A row that is not drawn is ignored, so that a focus
+         * left over from a collapsed subtree cannot blur the tree.
+         *
+         * @private
+         * @param {String} rowKey
+         */
+        _focusRow: function (rowKey) {
+            const $row = this._rowElement(rowKey);
+            if (!$row.length) {
+                return;
+            }
+            this.focusedKey = rowKey;
+            this._updateTabIndex();
+            $row[0].focus();
+        },
+
+        /**
+         * @private
+         * @param {Number} index position in the drawn rows
+         */
+        _focusIndex: function (index) {
+            if (index < 0 || index >= this.visibleRows.length) {
+                return;
+            }
+            this._focusRow(this.visibleRows[index].key);
+        },
+
+        /**
+         * @private
+         * @param {String} rowKey the row the move starts from
+         * @param {Number} delta how many rows to move, signed
+         */
+        _focusRelative: function (rowKey, delta) {
+            const index = this.visibleRows.findIndex((row) => row.key === rowKey);
+            if (index === -1) {
+                return;
+            }
+            this._focusIndex(index + delta);
+        },
+
+        /**
+         * Keeps exactly one row reachable with Tab, the focused one.
+         *
+         * @private
+         */
+        _updateTabIndex: function () {
+            this.$(".o_hierarchy_row").attr("tabindex", "-1");
+            this._rowElement(this.focusedKey).attr("tabindex", "0");
+        },
+
+        /**
+         * Opens a closed node; on an already open one, walks down to its
+         * first child instead.
+         *
+         * @private
+         * @param {Object} row
+         */
+        _keyboardExpand: function (row) {
+            if (row.hasChildren && !row.isOpen) {
+                this.trigger_up("hierarchy_toggle_node", {rowKey: row.key});
+                return;
+            }
+            if (row.isOpen && row.childKeys && row.childKeys.length) {
+                this._focusRow(row.childKeys[0]);
+            }
+        },
+
+        /**
+         * Closes an open node; on an already closed one, walks up to its
+         * parent instead.
+         *
+         * @private
+         * @param {Object} row
+         */
+        _keyboardCollapse: function (row) {
+            if (row.isOpen) {
+                this.trigger_up("hierarchy_toggle_node", {rowKey: row.key});
+                return;
+            }
+            if (row.parentKey && this.state.rows[row.parentKey]) {
+                this._focusRow(row.parentKey);
+            }
+        },
+
         // --------------------------------------------------------------------
         // Handlers
         // --------------------------------------------------------------------
@@ -197,6 +479,68 @@ odoo.define("ssi_web_hierarchy_view.HierarchyRenderer", function (require) {
             if (row) {
                 this.trigger_up("hierarchy_open_record", {id: row.id});
             }
+        },
+
+        /**
+         * Walks the tree from the keyboard. The focus stays on rows, never
+         * on cells, and only the keys of the contract are swallowed: every
+         * other one, Tab included, is left to the browser.
+         *
+         * @private
+         * @param {KeyboardEvent} event
+         */
+        _onRowKeydown: function (event) {
+            if (!HANDLED_KEYS.includes(event.key)) {
+                return;
+            }
+            const key = $(event.currentTarget).data("key");
+            const row = this.state.rows[key];
+            if (!row) {
+                return;
+            }
+            event.preventDefault();
+            event.stopPropagation();
+            switch (event.key) {
+                case KEY_DOWN:
+                    this._focusRelative(key, 1);
+                    break;
+                case KEY_UP:
+                    this._focusRelative(key, -1);
+                    break;
+                case KEY_RIGHT:
+                    this._keyboardExpand(row);
+                    break;
+                case KEY_LEFT:
+                    this._keyboardCollapse(row);
+                    break;
+                case KEY_ENTER:
+                    this.trigger_up("hierarchy_open_record", {id: row.id});
+                    break;
+                case KEY_HOME:
+                    this._focusIndex(0);
+                    break;
+                case KEY_END:
+                    this._focusIndex(this.visibleRows.length - 1);
+                    break;
+                // No default: HANDLED_KEYS has no other member.
+            }
+        },
+
+        /**
+         * Hands the roving tabindex over to whichever row took the focus,
+         * so that a row reached with Tab or with the mouse becomes the one
+         * the arrow keys start from.
+         *
+         * @private
+         * @param {FocusEvent} event
+         */
+        _onRowFocusIn: function (event) {
+            const key = $(event.currentTarget).data("key");
+            if (!this.state.rows[key] || key === this.focusedKey) {
+                return;
+            }
+            this.focusedKey = key;
+            this._updateTabIndex();
         },
     });
 

--- a/ssi_web_hierarchy_view/static/src/js/hierarchy_view.js
+++ b/ssi_web_hierarchy_view/static/src/js/hierarchy_view.js
@@ -1,3 +1,4 @@
+/* global py */
 /* Copyright 2026 OpenSynergy Indonesia
  * Copyright 2026 PT. Simetri Sinergi Indonesia
  * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
@@ -16,6 +17,25 @@ odoo.define("ssi_web_hierarchy_view.HierarchyView", function (require) {
 
     const DEFAULT_EXPAND = 0;
     const DEFAULT_LIMIT = 1000;
+
+    // Row decorations the hierarchy tag accepts, exactly the ones
+    // ssi_web_gantt accepts. The order is the order the classes are applied
+    // in, so a decoration listed later wins over an earlier one whenever
+    // several of them light up on the same row.
+    const DECORATIONS = [
+        "danger",
+        "warning",
+        "info",
+        "success",
+        "primary",
+        "secondary",
+        "muted",
+    ];
+
+    // Names read by a decoration expression. String literals are stripped
+    // before the match, so that a quoted word never passes for a field.
+    const IDENTIFIER_RE = /[A-Za-z_]\w*/g;
+    const STRING_LITERAL_RE = /'[^']*'|"[^"]*"/g;
 
     const HierarchyView = AbstractView.extend({
         display_name: _lt("Hierarchy"),
@@ -50,12 +70,14 @@ odoo.define("ssi_web_hierarchy_view.HierarchyView", function (require) {
 
             this.rendererParams.columns = columns;
             this.rendererParams.fields = fields;
+            this.rendererParams.decorations = this._parseDecorations(attrs);
 
             this.loadParams.modelName = this.controllerParams.modelName;
             this.loadParams.fieldNames = this._fieldNames(
                 columns,
                 childField,
-                parentField
+                parentField,
+                fields
             );
             this.loadParams.childField = childField;
             this.loadParams.parentField = parentField;
@@ -97,15 +119,18 @@ odoo.define("ssi_web_hierarchy_view.HierarchyView", function (require) {
          * Every field the tree reads has to be fetched by search_read/read:
          * the columns, plus ``child_field``/``parent_field`` themselves so
          * the model can tell whether a row has children and, in
-         * ``child_field`` mode, read them without an extra search.
+         * ``child_field`` mode, read them without an extra search, plus the
+         * fields a decoration expression reads, which are usually no
+         * column at all.
          *
          * @private
          * @param {Array} columns
          * @param {String|Boolean} childField
          * @param {String|Boolean} parentField
+         * @param {Object} fields viewInfo.fields
          * @returns {Array}
          */
-        _fieldNames: function (columns, childField, parentField) {
+        _fieldNames: function (columns, childField, parentField, fields) {
             const names = ["display_name"];
             for (const column of columns) {
                 names.push(column.name);
@@ -116,7 +141,60 @@ odoo.define("ssi_web_hierarchy_view.HierarchyView", function (require) {
             if (parentField) {
                 names.push(parentField);
             }
+            for (const name of this._decorationFieldNames(fields)) {
+                names.push(name);
+            }
             return _.uniq(names);
+        },
+
+        /**
+         * Compiles the ``decoration-*`` attributes of the arch once, so
+         * that the renderer only ever evaluates an already parsed
+         * expression, once per row and per decoration.
+         *
+         * @private
+         * @param {Object} attrs the arch attributes
+         * @returns {Object} compiled expressions, keyed by decoration
+         */
+        _parseDecorations: function (attrs) {
+            const decorations = {};
+            for (const decoration of DECORATIONS) {
+                const expression = attrs["decoration-" + decoration];
+                if (expression) {
+                    decorations[decoration] = py.parse(py.tokenize(expression));
+                }
+            }
+            return decorations;
+        },
+
+        /**
+         * The fields read by the decoration expressions. The server
+         * registers every one of them on the view, so a name is taken for
+         * a field exactly when it is one of the view's own fields; a
+         * symbol of the evaluation context (``uid``, ``today``, ...) never
+         * is.
+         *
+         * @private
+         * @param {Object} fields viewInfo.fields
+         * @returns {Array}
+         */
+        _decorationFieldNames: function (fields) {
+            const names = [];
+            for (const decoration of DECORATIONS) {
+                const expression = this.arch.attrs["decoration-" + decoration];
+                if (!expression) {
+                    continue;
+                }
+                const tokens =
+                    expression.replace(STRING_LITERAL_RE, " ").match(IDENTIFIER_RE) ||
+                    [];
+                for (const token of tokens) {
+                    if (fields[token]) {
+                        names.push(token);
+                    }
+                }
+            }
+            return names;
         },
     });
 

--- a/ssi_web_hierarchy_view/static/src/scss/hierarchy.scss
+++ b/ssi_web_hierarchy_view/static/src/scss/hierarchy.scss
@@ -12,11 +12,19 @@
 .o_hierarchy_table {
     margin-bottom: 0;
 
+    // The header stays put while the tree scrolls, with CSS alone: the
+    // scroll container is .o_hierarchy_view above, so no scroll listener and
+    // no position arithmetic is needed anywhere in the JS.
     thead th {
         position: sticky;
         top: 0;
         z-index: 1;
         background-color: #f8f9fa;
+        // A collapsed border is painted by the table, not by the cell, so
+        // it would scroll away from under a sticky header. Painting it as a
+        // box shadow keeps it stuck to the header instead.
+        border-bottom: 0;
+        box-shadow: inset 0 -1px 0 #dee2e6;
     }
 }
 
@@ -25,6 +33,13 @@
 
     &:hover {
         background-color: #f1f3f5;
+    }
+
+    // The tree is walked with the keyboard, so the focused row has to be
+    // visible as such. outline-offset keeps the ring inside the row.
+    &:focus {
+        outline: 2px solid #7c7bad;
+        outline-offset: -2px;
     }
 }
 
@@ -49,6 +64,41 @@
     .o_hierarchy_label {
         font-style: italic;
     }
+}
+
+// Row decorations, coloured like the semantic text classes a list view uses
+// for its own decoration-* attributes. They are declared after the search
+// mode classes on purpose: a decoration asked for by the arch outranks the
+// grey of a context row. Several decorations may light up on one row at
+// once, and since the declarations below share one specificity, the order
+// they are written in is the order they are applied in: the last one of the
+// list that lights up is the colour actually seen.
+.o_hierarchy_row.o_hierarchy_row_danger {
+    color: #dc3545;
+}
+
+.o_hierarchy_row.o_hierarchy_row_warning {
+    color: #b8860b;
+}
+
+.o_hierarchy_row.o_hierarchy_row_info {
+    color: #17a2b8;
+}
+
+.o_hierarchy_row.o_hierarchy_row_success {
+    color: #28a745;
+}
+
+.o_hierarchy_row.o_hierarchy_row_primary {
+    color: #007bff;
+}
+
+.o_hierarchy_row.o_hierarchy_row_secondary {
+    color: #6c757d;
+}
+
+.o_hierarchy_row.o_hierarchy_row_muted {
+    color: #adb5bd;
 }
 
 .o_hierarchy_cell_main {

--- a/ssi_web_hierarchy_view/static/src/xml/hierarchy.xml
+++ b/ssi_web_hierarchy_view/static/src/xml/hierarchy.xml
@@ -18,8 +18,8 @@
     </t>
 
     <t t-name="ssi_web_hierarchy_view.Table">
-        <table class="table table-sm o_hierarchy_table">
-            <thead>
+        <table class="table table-sm o_hierarchy_table" role="tree">
+            <thead role="presentation">
                 <tr>
                     <th class="o_hierarchy_header_main">
                         <t t-if="columns.length" t-esc="columns[0].label" />
@@ -30,11 +30,17 @@
                     </t>
                 </tr>
             </thead>
-            <tbody>
+            <tbody role="presentation">
                 <t t-foreach="rows" t-as="row">
                     <tr
                         t-attf-class="o_hierarchy_row #{widget.rowClass(row)}"
                         t-att-data-key="row.key"
+                        role="treeitem"
+                        t-att-aria-level="widget.ariaLevel(row)"
+                        t-att-aria-expanded="widget.ariaExpanded(row)"
+                        t-att-aria-setsize="widget.ariaSetSize(row)"
+                        t-att-aria-posinset="widget.ariaPosInSet(row)"
+                        t-att-tabindex="widget.rowTabIndex(row)"
                     >
                         <td class="o_hierarchy_cell_main">
                             <span

--- a/ssi_web_hierarchy_view/tests/test_data_ssi_web_hierarchy_view.yaml
+++ b/ssi_web_hierarchy_view/tests/test_data_ssi_web_hierarchy_view.yaml
@@ -252,6 +252,145 @@ scenarios:
             operator: "contains"
             expected: 'parent_field="parent_id"'
 
+  - name: "ssi_web_hierarchy_view - Arch without any decoration is accepted"
+    steps:
+      - step: "Create a hierarchy view declaring no decoration at all"
+        action: "create"
+        model: "ir.ui.view"
+        save_as: "view"
+        values:
+          name: "Partner Hierarchy Without Decoration"
+          model: "res.partner"
+          type: "hierarchy"
+          arch: |
+            <hierarchy parent_field="parent_id">
+                <field name="name" />
+            </hierarchy>
+      - step: "Assert the view is stored as a hierarchy view"
+        action: "assert"
+        target: "view"
+        asserts:
+          type:
+            type: "value"
+            expected: "hierarchy"
+
+  - name: "ssi_web_hierarchy_view - All seven decorations are accepted at once"
+    steps:
+      - step: "Create a hierarchy view carrying every supported decoration"
+        action: "create"
+        model: "ir.ui.view"
+        save_as: "view"
+        values:
+          name: "Partner Hierarchy All Decorations"
+          model: "res.partner"
+          type: "hierarchy"
+          arch: |
+            <hierarchy
+                parent_field="parent_id"
+                decoration-danger="not active"
+                decoration-warning="is_company"
+                decoration-info="type == 'contact'"
+                decoration-success="employee"
+                decoration-primary="color == 1"
+                decoration-secondary="phone == False"
+                decoration-muted="comment == False"
+            >
+                <field name="name" />
+            </hierarchy>
+      - step: "Assert every decoration survived the arch validation"
+        action: "assert"
+        target: "view"
+        asserts:
+          type:
+            type: "value"
+            expected: "hierarchy"
+          arch_db:
+            type: "value"
+            operator: "contains"
+            expected: "decoration-danger"
+      - step: "Assert the last decoration of the list survived too"
+        action: "assert"
+        target: "view"
+        asserts:
+          arch_db:
+            type: "value"
+            operator: "contains"
+            expected: "decoration-muted"
+
+  - name: "ssi_web_hierarchy_view - Decoration may read a field outside the columns"
+    steps:
+      - step: "Create a view whose decoration reads a field that is no column"
+        action: "create"
+        model: "ir.ui.view"
+        save_as: "view"
+        values:
+          name: "Partner Hierarchy Decoration Field Not A Column"
+          model: "res.partner"
+          type: "hierarchy"
+          arch: |
+            <hierarchy parent_field="parent_id" decoration-danger="not active">
+                <field name="name" />
+            </hierarchy>
+      - step: "Assert the arch was accepted and stored"
+        action: "assert"
+        target: "view"
+        asserts:
+          type:
+            type: "value"
+            expected: "hierarchy"
+          arch_db:
+            type: "value"
+            operator: "contains"
+            expected: 'decoration-danger="not active"'
+
+  - name: "ssi_web_hierarchy_view - Unsupported decoration suffix is rejected"
+    steps:
+      - step: "Create a hierarchy view carrying decoration-mantap"
+        action: "create"
+        model: "ir.ui.view"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "decoration-mantap"
+        values:
+          name: "Partner Hierarchy Unsupported Decoration"
+          model: "res.partner"
+          type: "hierarchy"
+          arch: |
+            <hierarchy parent_field="parent_id" decoration-mantap="not active" />
+
+  - name: "ssi_web_hierarchy_view - Decoration reading an unknown field is rejected"
+    steps:
+      - step: "Create a view whose decoration reads a field of no model"
+        action: "create"
+        model: "ir.ui.view"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "does not exist"
+        values:
+          name: "Partner Hierarchy Decoration Unknown Field"
+          model: "res.partner"
+          type: "hierarchy"
+          arch: |
+            <hierarchy
+                parent_field="parent_id"
+                decoration-danger="no_such_field_at_all"
+            />
+
+  - name: "ssi_web_hierarchy_view - Decoration that is not Python is rejected"
+    steps:
+      - step: "Create a view whose decoration is not a Python expression"
+        action: "create"
+        model: "ir.ui.view"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "not a valid Python expression"
+        values:
+          name: "Partner Hierarchy Decoration Not Python"
+          model: "res.partner"
+          type: "hierarchy"
+          arch: |
+            <hierarchy parent_field="parent_id" decoration-danger="not ==" />
+
   - name: "ssi_web_hierarchy_view - Action view_mode accepts hierarchy"
     steps:
       - step: "Create a hierarchy view on res.partner"

--- a/ssi_web_hierarchy_view/tests/test_ssi_web_hierarchy_view.py
+++ b/ssi_web_hierarchy_view/tests/test_ssi_web_hierarchy_view.py
@@ -34,9 +34,83 @@ class TestSsiWebHierarchyView(YamlTransactionCase):
         )
         return grandparent, parent, child
 
+    def _create_hierarchy_view(self, name, arch):
+        """Create a ``hierarchy`` view on ``res.partner``.
+
+        :param name: name of the view, unique per test
+        :param arch: the arch of the view
+        :return: the created ``ir.ui.view`` record
+        """
+        return self.env["ir.ui.view"].create(
+            {
+                "name": name,
+                "model": "res.partner",
+                "type": "hierarchy",
+                "arch": arch,
+            }
+        )
+
     def test_ssi_web_hierarchy_view(self):
         """Run the ``hierarchy`` view type arch validation scenarios."""
         self.run_yaml_scenario("test_data_ssi_web_hierarchy_view.yaml")
+
+    def test_decoration_field_is_reported_to_the_browser(self):
+        """Assert a decoration-only field is reported by the view.
+
+        A field read by a ``decoration-*`` expression is usually no
+        column of the tree, so nothing else declares it; the browser only
+        fetches the fields the view reports, hence it has to be reported
+        even though no ``<field>`` names it.
+
+        Pure Python — trigger P1 (L-01: what is under test is the dict
+        ``fields_view_get`` returns, and L-02 only lets an assert reach a
+        field of a record, never a returned dict).
+        """
+        view = self._create_hierarchy_view(
+            "SSIWHV Decoration Field Reported",
+            """
+            <hierarchy parent_field="parent_id" decoration-danger="not active">
+                <field name="name" />
+            </hierarchy>
+            """,
+        )
+        result = self.env["res.partner"].fields_view_get(
+            view_id=view.id, view_type="hierarchy"
+        )
+        self.assertIn("active", result["fields"])
+        self.assertIn("name", result["fields"])
+        self.assertIn("parent_id", result["fields"])
+
+    def test_every_field_of_a_decoration_is_reported(self):
+        """Assert an expression reading several fields reports them all.
+
+        A field never named by any ``<field>`` and a field only named by
+        another decoration have to be reported just the same, otherwise
+        the expression would be evaluated against a value the browser
+        never fetched.
+
+        Pure Python — trigger P1 (L-01: what is under test is the dict
+        ``fields_view_get`` returns, and L-02 only lets an assert reach a
+        field of a record, never a returned dict).
+        """
+        view = self._create_hierarchy_view(
+            "SSIWHV Decoration Fields Reported",
+            """
+            <hierarchy
+                parent_field="parent_id"
+                decoration-warning="is_company and color == 1"
+                decoration-muted="employee"
+            >
+                <field name="name" />
+            </hierarchy>
+            """,
+        )
+        result = self.env["res.partner"].fields_view_get(
+            view_id=view.id, view_type="hierarchy"
+        )
+        self.assertIn("is_company", result["fields"])
+        self.assertIn("color", result["fields"])
+        self.assertIn("employee", result["fields"])
 
     def test_search_ancestors_of_a_grandchild(self):
         """Assert the parent chain returned for a deep match.


### PR DESCRIPTION
Menutup issue #81.

## Perubahan

* **decoration-* per baris** pada tag `hierarchy`. Tujuh sufiks yang sah — `danger`,
  `warning`, `info`, `success`, `primary`, `secondary`, `muted` — sama persis dengan
  `ssi_web_gantt`. Sufiks di luar daftar (mis. `decoration-mantap`) dan ekspresi yang
  bukan Python sah **ditolak saat validasi arch** dengan pesan berformat SSI
  (Context/Database ID/Problem/Solution), bukan diabaikan senyap.
* **Field yang hanya dibaca ekspresi dekorasi** didaftarkan ke name manager, sehingga ikut
  dilaporkan `fields_view_get` dan ikut diambil browser meski bukan kolom. Efek sampingnya:
  ekspresi yang menyebut field tak ada gagal saat view disimpan, bukan di browser.
* **Kelas baris** `o_hierarchy_row_<sufiks>`, hidup berdampingan dengan
  `o_hierarchy_match`/`o_hierarchy_context` milik mode pencarian; beberapa dekorasi boleh
  menyala bersamaan dan urutan penerapannya mengikuti urutan daftar sufiks.
* **Header kolom sticky** lewat CSS murni (`position: sticky`) — tanpa listener scroll
  atau perhitungan posisi di JS.
* **Navigasi keyboard penuh**: `ArrowDown`/`ArrowUp`, `ArrowRight` (buka node, lalu turun
  ke anak pertama), `ArrowLeft` (tutup node, lalu naik ke induk), `Enter` (buka form view),
  `Home`/`End`. Roving tabindex membuat `Tab` melompati isi pohon. ARIA: `role=tree` /
  `role=treeitem`, `aria-level`, `aria-expanded` (hanya node berisi anak),
  `aria-setsize`/`aria-posinset`.

## Uji

* Skenario `odoo-yaml-test` baru: tujuh dekorasi sekaligus tersimpan, dekorasi membaca
  field di luar kolom tersimpan, arch tanpa dekorasi tetap tersimpan; negatif —
  `decoration-mantap`, field tak dikenal, dan ekspresi bukan Python sah.
* Unit test Python (P1) memastikan field yang hanya dibaca dekorasi benar-benar dilaporkan
  `fields_view_get`.
* Tidak ada test/assertion dari #79/#80 yang dihapus, di-skip, atau dilonggarkan.

Closes #81