### PR TITLE
[UPD] ssi_web_hierarchy_view: agregasi kolom numerik pada baris induk

### DIFF
--- a/ssi_web_hierarchy_view/README.rst
+++ b/ssi_web_hierarchy_view/README.rst
@@ -20,8 +20,8 @@ flat list or through a ``child_of`` filter.
 
 This iteration is **read only**: dragging a row to reparent it, inline edit
 and ``groupBy`` are out of scope. Per column ``decoration-*``
-(``<field decoration-…>``), user resizable or hideable columns and numeric
-column aggregation (``sum=``) are not implemented either.
+(``<field decoration-…>``) and user resizable or hideable columns are not
+implemented either.
 
 Usage
 =====
@@ -74,6 +74,57 @@ The first ``<field>`` child of the ``hierarchy`` tag is the hierarchy column:
 it carries the indentation and the expand/collapse toggle. Every other
 ``<field>`` is a plain column. Without any ``<field>`` at all, the hierarchy
 column falls back to ``display_name``.
+
+Numeric column totals
+---------------------
+
+A numeric column carries ``sum="<label>"``, spelled exactly like a list
+view's own aggregate attribute. Every parent row then shows the total of its
+**whole subtree** instead of its own value, and a grand total row is drawn at
+the very bottom of the tree::
+
+    <hierarchy parent_field="parent_id">
+        <field name="name" />
+        <field name="balance" sum="Total Balance" />
+    </hierarchy>
+
+* Only ``integer``, ``float`` and ``monetary`` fields may carry ``sum``, and
+  only if they are **stored**: the total is computed server side with a
+  query, so a non-stored computed column cannot be summed. Anything else is
+  **rejected when the view is saved** rather than silently showing nothing.
+* The total of a parent row **includes the value of that row itself**, so a
+  parent total always equals the sum of the column as it is displayed
+  underneath it — which is what the reader of a chart of accounts expects.
+* A **leaf** row shows its own value, without the total styling: there is
+  nothing summed underneath it.
+* A cell showing a total carries the class ``o_hierarchy_aggregate``, so a
+  total can be told apart from a plain value and restyled by a database
+  without touching this module.
+* The **grand total row** adds up the subtree totals of the roots currently
+  on screen, so it follows the active domain and the active page of the
+  pager. The label given to ``sum=`` is its tooltip.
+* In a ``child_field``-only view every record matching the domain is a root
+  (see *Determining the hierarchy*), so the grand total adds up subtree
+  totals that overlap and a descendant is counted once per ancestor of it on
+  screen. Add ``parent_field`` next to ``child_field`` to get a grand total
+  that counts every record exactly once.
+* Rounding and formatting follow the field itself: ``digits`` for a float, and
+  for a ``monetary`` column the currency named by the ``currency_field`` that
+  field declares — the view fetches that currency field next to the column
+  for that very reason. The grand total row reads its currency from the first
+  root on screen.
+
+The totals are computed by ``hierarchy_aggregate(node_ids, field_names,
+parent_field=None, child_field=None)``, a method this module adds to every
+model. It returns ``{node_id: {field_name: total}}`` with one entry per given
+id, and is called **once per level** — for every id of that level at once,
+never once per node. Descendants are walked through ``parent_field`` when it
+is set and through ``child_field`` otherwise; ``child_of`` is deliberately
+not used, since it would require the walked field to be the model's
+``_parent_name``. Access rights are honoured — there is no ``sudo()``: a
+descendant the user may not read is left out of the total, consistently with
+the rows that user sees. A tree nested deeper than 64 levels is treated as
+cyclic data and raises, rather than looping forever.
 
 Row decorations
 ---------------
@@ -241,7 +292,9 @@ Known limitations
   a single cell in a list view, is not supported.
 * No user resizable or hideable columns, and no preference remembering
   either.
-* No numeric column aggregation (``sum=``).
+* Column aggregation is a **sum** only: ``avg=``, ``min=``, ``max=`` and a
+  count of the descendants are not supported, and neither is exporting the
+  totals to XLSX/CSV.
 
 Installation
 ============

--- a/ssi_web_hierarchy_view/models/base.py
+++ b/ssi_web_hierarchy_view/models/base.py
@@ -10,13 +10,23 @@ from odoo.exceptions import UserError
 # hierarchy, so the walk raises instead of looping forever.
 HIERARCHY_MAX_DEPTH = 64
 
+# Field types a subtree total may be computed for, exactly the ones a list
+# view aggregates with its own ``sum=``. The total of anything else is
+# meaningless, and a field that is not stored cannot be queried at all.
+HIERARCHY_AGGREGATABLE_TYPES = [
+    "integer",
+    "float",
+    "monetary",
+]
+
 
 class Base(models.AbstractModel):
     """
-    Adds the server side of the hierarchy view's search mode to every
-    model: one single call returns the records matching a domain together
-    with their whole parent chain, so that the browser never has to walk
-    that chain with one RPC per level.
+    Adds the server side of the hierarchy view to every model: one single
+    call returns the records matching a domain together with their whole
+    parent chain, so that the browser never has to walk that chain with
+    one RPC per level, and one single call returns the subtree total of a
+    numeric column for a whole level of nodes at once.
     """
 
     _inherit = "base"
@@ -150,5 +160,261 @@ Solution: Break the parent loop in the data of model %s
                 HIERARCHY_MAX_DEPTH,
                 self._name,
             )
+        )
+        raise UserError(error_message)
+
+    def hierarchy_aggregate(
+        self, node_ids, field_names, parent_field=None, child_field=None
+    ):
+        """Return the subtree total of every field for every given node.
+
+        Called by the ``hierarchy`` view once per level, for every id of
+        that level at once rather than once per node, so that opening a
+        node costs one query per level of its subtree instead of one
+        query per descendant.
+
+        The total reported for a node **includes the value of the node
+        itself**: that is what the reader of a chart of accounts expects,
+        and it keeps the total of a parent equal to the sum of the column
+        as it is displayed underneath it.
+
+        Descendants are walked through ``parent_field`` when it is given
+        and through ``child_field`` otherwise. ``child_of`` is
+        deliberately not used: it requires the walked field to be the
+        ``_parent_name`` of the model, which nothing guarantees here.
+
+        Access rights are honoured — there is no ``sudo()`` anywhere — so
+        a descendant the current user may not read is left out of the
+        total, consistently with the rows that user sees in the tree.
+
+        :param node_ids: ids of the nodes a total is asked for
+        :param field_names: names of the numeric stored fields to total
+        :param parent_field: name of the ``many2one`` to this same model
+            carrying the parent of a record, ``None`` to walk
+            ``child_field`` instead
+        :param child_field: name of the ``one2many``/``many2many`` to
+            this same model carrying the children of a record, used only
+            when ``parent_field`` is not given
+        :return: dict ``{node_id: {field_name: total}}`` holding one
+            entry for every id of ``node_ids``
+        :raises UserError: when a field of ``field_names`` does not
+            exist, is not numeric or is not stored, when neither
+            ``parent_field`` nor ``child_field`` is given, or when the
+            tree is nested deeper than ``HIERARCHY_MAX_DEPTH`` levels,
+            which only happens on cyclic data
+        """
+        self._check_hierarchy_aggregate_fields(field_names)
+        self._check_hierarchy_walk_fields(parent_field, child_field)
+        subtree_ids = self._hierarchy_subtree_ids(node_ids, parent_field, child_field)
+        values = self._hierarchy_aggregate_values(subtree_ids, field_names)
+        totals = {}
+        for node_id, record_ids in subtree_ids.items():
+            totals[node_id] = {
+                field_name: sum(
+                    values[record_id].get(field_name) or 0
+                    for record_id in record_ids
+                    if record_id in values
+                )
+                for field_name in field_names
+            }
+        return totals
+
+    def _check_hierarchy_aggregate_fields(self, field_names):
+        """Reject a field that carries no summable stored value.
+
+        Extension point: override to accept another kind of column
+        without touching :meth:`hierarchy_aggregate` itself.
+
+        :param field_names: names of the fields to total
+        :raises UserError: when a field does not exist on this model, is
+            of a type outside ``HIERARCHY_AGGREGATABLE_TYPES``, or is not
+            stored and can therefore not be queried
+        """
+        for field_name in field_names:
+            field = self._fields.get(field_name)
+            if field is None:
+                error_message = _(
+                    """
+Context: Aggregate a hierarchy view column
+Database ID: %s
+Problem: Field %s does not exist on model %s
+Solution: Set sum on a field that exists on model %s
+"""
+                    % (self.id, field_name, self._name, self._name)
+                )
+                raise UserError(error_message)
+
+            if field.type not in HIERARCHY_AGGREGATABLE_TYPES:
+                error_message = _(
+                    """
+Context: Aggregate a hierarchy view column
+Database ID: %s
+Problem: Field %s of model %s is not a numeric field
+Solution: Set sum on a field of type %s
+"""
+                    % (
+                        self.id,
+                        field_name,
+                        self._name,
+                        ", ".join(HIERARCHY_AGGREGATABLE_TYPES),
+                    )
+                )
+                raise UserError(error_message)
+
+            if not field.store:
+                error_message = _(
+                    """
+Context: Aggregate a hierarchy view column
+Database ID: %s
+Problem: Field %s of model %s is not stored
+Solution: Set sum on a stored field, a total is queried server side
+"""
+                    % (self.id, field_name, self._name)
+                )
+                raise UserError(error_message)
+
+    def _check_hierarchy_walk_fields(self, parent_field, child_field):
+        """Reject an aggregation that cannot walk the tree downwards.
+
+        :param parent_field: value of the arch's ``parent_field``
+        :param child_field: value of the arch's ``child_field``
+        :raises UserError: when neither of the two is given, leaving no
+            way at all to reach the descendants of a node
+        """
+        if parent_field or child_field:
+            return
+
+        error_message = _(
+            """
+Context: Aggregate a hierarchy view column
+Database ID: %s
+Problem: Neither parent_field nor child_field was given for model %s
+Solution: Add parent_field, child_field, or both to the hierarchy tag
+"""
+            % (self.id, self._name)
+        )
+        raise UserError(error_message)
+
+    def _hierarchy_subtree_ids(self, node_ids, parent_field, child_field):
+        """Walk the tree downwards and collect the subtree of each node.
+
+        The walk is breadth first, one level per iteration, so a whole
+        level costs a single query no matter how many nodes it holds. A
+        record is only ever counted once per subtree, so a node reachable
+        through two different parents of one and the same subtree is not
+        summed twice.
+
+        :param node_ids: ids of the nodes a subtree is asked for
+        :param parent_field: name of the ``many2one`` to this same model,
+            or ``None``
+        :param child_field: name of the ``one2many``/``many2many`` to
+            this same model, used when ``parent_field`` is ``None``
+        :return: dict ``{node_id: set of ids}``, every set holding the
+            node itself besides its descendants
+        :raises UserError: when more than ``HIERARCHY_MAX_DEPTH`` levels
+            are walked, which only happens on cyclic data
+        """
+        subtree_ids = {node_id: {node_id} for node_id in node_ids}
+        # Ids of the level being walked, mapped to the requested nodes
+        # whose subtree they belong to. One id may well belong to several
+        # of them at once, whenever a node and its own ancestor are both
+        # part of ``node_ids``.
+        level = {node_id: {node_id} for node_id in node_ids}
+        depth = 0
+        while level:
+            children_ids = self._hierarchy_children_ids(
+                sorted(level), parent_field, child_field
+            )
+            next_level = {}
+            for parent_id, child_ids in children_ids.items():
+                for child_id in child_ids:
+                    owner_ids = next_level.setdefault(child_id, set())
+                    owner_ids.update(level[parent_id])
+            if not next_level:
+                break
+            depth += 1
+            if depth > HIERARCHY_MAX_DEPTH:
+                self._raise_hierarchy_aggregate_depth_error()
+            for child_id, owner_ids in next_level.items():
+                for owner_id in owner_ids:
+                    subtree_ids[owner_id].add(child_id)
+            level = next_level
+        return subtree_ids
+
+    def _hierarchy_children_ids(self, node_ids, parent_field, child_field):
+        """Read the children of a whole level in one single query.
+
+        ``parent_field`` is preferred whenever it is given: searching on
+        it already leaves out the records the current user may not read,
+        whereas the ids carried by ``child_field`` would have to be
+        filtered afterwards.
+
+        :param node_ids: ids of the level the children are read for
+        :param parent_field: name of the ``many2one`` to this same model,
+            or ``None``
+        :param child_field: name of the ``one2many``/``many2many`` to
+            this same model, used when ``parent_field`` is ``None``
+        :return: dict ``{node_id: list of child ids}``, holding no entry
+            at all for a node without children
+        """
+        children_ids = {}
+        if parent_field:
+            for record in self.search_read(
+                [(parent_field, "in", node_ids)], [parent_field]
+            ):
+                parent_value = record[parent_field]
+                parent_id = parent_value[0] if parent_value else False
+                if parent_id:
+                    children_ids.setdefault(parent_id, []).append(record["id"])
+            return children_ids
+
+        for record in self.search_read([("id", "in", node_ids)], [child_field]):
+            if record[child_field]:
+                children_ids[record["id"]] = list(record[child_field])
+        return children_ids
+
+    def _hierarchy_aggregate_values(self, subtree_ids, field_names):
+        """Read the values every subtree total is built from.
+
+        One single query for the union of every subtree: a record belongs
+        to the subtree of each one of its ancestors, so reading node by
+        node would read that record over and over again.
+
+        The read goes through ``search_read`` and therefore through the
+        record rules of the current user, which is what keeps a
+        descendant that user may not read out of the totals.
+
+        :param subtree_ids: dict ``{node_id: set of ids}`` as returned by
+            :meth:`_hierarchy_subtree_ids`
+        :param field_names: names of the numeric fields to read
+        :return: dict ``{record_id: {field_name: value}}``, holding no
+            entry for a record the current user may not read
+        """
+        all_ids = set()
+        for record_ids in subtree_ids.values():
+            all_ids.update(record_ids)
+        if not all_ids:
+            return {}
+
+        values = {}
+        for record in self.search_read(
+            [("id", "in", sorted(all_ids))], list(field_names)
+        ):
+            values[record["id"]] = record
+        return values
+
+    def _raise_hierarchy_aggregate_depth_error(self):
+        """Report a subtree walk that never reaches a leaf record.
+
+        :raises UserError: always
+        """
+        error_message = _(
+            """
+Context: Aggregate a hierarchy view column
+Database ID: %s
+Problem: Model %s is nested deeper than %s levels
+Solution: Break the parent loop in the data of model %s
+"""
+            % (self.id, self._name, HIERARCHY_MAX_DEPTH, self._name)
         )
         raise UserError(error_message)

--- a/ssi_web_hierarchy_view/models/ir_ui_view.py
+++ b/ssi_web_hierarchy_view/models/ir_ui_view.py
@@ -5,6 +5,13 @@
 from odoo import _, fields, models
 from odoo.tools.view_validation import get_variable_names
 
+from .base import HIERARCHY_AGGREGATABLE_TYPES
+
+# Attribute of a <field> child asking for the subtree total of that column
+# to be shown on every parent row. Its value is the label of the grand
+# total row, spelled exactly like the list view's own aggregate attribute.
+AGGREGATE_ATTRIBUTE = "sum"
+
 # Arch attributes naming a field of the view's own model. Both are
 # registered on the name manager exactly like a <field> child, so the
 # generic field-existence check already rejects an arch pointing at a field
@@ -56,7 +63,8 @@ class IrUiView(models.Model):
         an arch that points at a field which does not exist, without any
         extra code here. The fields read by a ``decoration-*`` expression
         are registered the same way, so that they are fetched by the
-        browser even when they are no column of the tree.
+        browser even when they are no column of the tree, and so is the
+        currency field of a monetary column asking for a total.
 
         :param node: the ``<hierarchy>`` arch element
         :param name_manager: the view's ``NameManager``
@@ -68,12 +76,114 @@ class IrUiView(models.Model):
                 name_manager.has_field(value, {})
 
         self._register_hierarchy_decoration_fields(node, name_manager)
+        self._register_hierarchy_aggregate_fields(node, name_manager)
 
         if name_manager.validate:
             self._validate_hierarchy_fields(node, name_manager.Model)
             self._validate_hierarchy_decorations(node)
+            self._validate_hierarchy_aggregates(node, name_manager.Model)
 
         node_info["editable"] = False
+
+    def _hierarchy_aggregates(self, node):
+        """Return the columns of the hierarchy tag asking for a total.
+
+        :param node: the ``<hierarchy>`` arch element
+        :return: dict ``{field_name: label}`` built from the ``<field>``
+            children carrying a ``sum`` attribute, the field name being
+            whatever ``name`` holds and not necessarily an existing field
+        """
+        aggregates = {}
+        for child in node:
+            if child.tag != "field":
+                continue
+            field_name = child.get("name")
+            label = child.get(AGGREGATE_ATTRIBUTE)
+            if field_name and label:
+                aggregates[field_name] = label
+        return aggregates
+
+    def _register_hierarchy_aggregate_fields(self, node, name_manager):
+        """Register the currency field of every monetary total column.
+
+        A monetary value is formatted with the currency held by the
+        ``currency_field`` the field itself declares, and that currency
+        field is usually no column of the tree, so nothing else declares
+        it. Registering it here makes ``fields_view_get`` report it, which
+        is what the browser fetches.
+
+        :param node: the ``<hierarchy>`` arch element
+        :param name_manager: the view's ``NameManager``
+        """
+        model = name_manager.Model
+        for field_name in self._hierarchy_aggregates(node):
+            field = model._fields.get(field_name)
+            if field is None or field.type != "monetary":
+                continue
+            currency_field = getattr(field, "currency_field", None)
+            if currency_field and currency_field in model._fields:
+                name_manager.has_field(currency_field, {})
+
+    def _validate_hierarchy_aggregates(self, node, model):
+        """Validate the ``sum`` attribute of the hierarchy columns.
+
+        A total is computed server side by querying the column, so only a
+        stored numeric field may carry ``sum``: a column of another type
+        has no meaningful total and would silently show nothing at all,
+        and a field that is not stored cannot be queried. A field that
+        does not exist is left to the generic name manager check, which
+        already reports "Field ... does not exist".
+
+        :param node: the ``<hierarchy>`` arch element
+        :param model: the recordset of the view's model
+        """
+        for field_name in self._hierarchy_aggregates(node):
+            field = model._fields.get(field_name)
+            if field is None:
+                continue
+            if field.type not in HIERARCHY_AGGREGATABLE_TYPES:
+                self._raise_hierarchy_aggregate_type_error(field_name, model)
+            elif not field.store:
+                self._raise_hierarchy_aggregate_store_error(field_name, model)
+
+    def _raise_hierarchy_aggregate_type_error(self, field_name, model):
+        """Reject a ``sum`` asked for on a column that is not numeric.
+
+        :param field_name: name of the field carrying ``sum``
+        :param model: the recordset of the view's model
+        """
+        error_message = _(
+            """
+Context: Validate hierarchy view architecture
+Database ID: %s
+Problem: Attribute sum on field %s of model %s needs a numeric field
+Solution: Set sum on a field of type %s
+"""
+            % (
+                self.id,
+                field_name,
+                model._name,
+                ", ".join(HIERARCHY_AGGREGATABLE_TYPES),
+            )
+        )
+        self.handle_view_error(error_message)
+
+    def _raise_hierarchy_aggregate_store_error(self, field_name, model):
+        """Reject a ``sum`` asked for on a column that is not stored.
+
+        :param field_name: name of the field carrying ``sum``
+        :param model: the recordset of the view's model
+        """
+        error_message = _(
+            """
+Context: Validate hierarchy view architecture
+Database ID: %s
+Problem: Attribute sum on field %s of model %s needs a stored field
+Solution: Set sum on a stored field, a total is queried server side
+"""
+            % (self.id, field_name, model._name)
+        )
+        self.handle_view_error(error_message)
 
     def _hierarchy_decorations(self, node):
         """Return the ``decoration-*`` attributes of the hierarchy tag.

--- a/ssi_web_hierarchy_view/static/src/js/hierarchy_model.js
+++ b/ssi_web_hierarchy_view/static/src/js/hierarchy_model.js
@@ -44,6 +44,10 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
             this.limitReached = false;
             this.searchMode = false;
             this.searchTruncated = false;
+            // Grand totals of the aggregated columns over the roots on
+            // screen, keyed by field name. Empty when no column asks for
+            // a total at all.
+            this.totals = {};
         },
 
         /**
@@ -61,6 +65,7 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
                 limitReached: this.limitReached,
                 searchMode: this.searchMode,
                 searchTruncated: this.searchTruncated,
+                totals: this.totals,
             };
         },
 
@@ -72,6 +77,7 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
             this.fieldNames = params.fieldNames;
             this.childField = params.childField;
             this.parentField = params.parentField;
+            this.aggregateFieldNames = params.aggregateFieldNames || [];
             this.defaultExpand = params.defaultExpand;
             this.nodeLimit = params.limit;
             this.domain = params.domain || [];
@@ -239,6 +245,7 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
                     this.rows = {};
                     this.rootKeys = [];
                     this.rootCount = 0;
+                    this.totals = {};
                     return Promise.resolve();
                 }
                 return this._rpc({
@@ -249,7 +256,14 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
                         fields: this.fieldNames,
                         context: this.context,
                     },
-                }).then((records) => this._buildSearchTree(records, result.matches));
+                }).then((records) => {
+                    this._buildSearchTree(records, result.matches);
+                    // The whole result tree is already in memory here, so
+                    // one single call covers every level of it at once.
+                    return this._fetchAggregates(Object.keys(this.rows)).then(() =>
+                        this._computeTotals()
+                    );
+                });
             });
         },
 
@@ -353,7 +367,9 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
                 this.rootKeys = records.map((record) =>
                     this._registerRow(record, false, 0)
                 );
-                return this._computeHasChildren(this.rootKeys);
+                return this._computeHasChildren(this.rootKeys)
+                    .then(() => this._fetchAggregates(this.rootKeys))
+                    .then(() => this._computeTotals());
             });
         },
 
@@ -395,6 +411,11 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
                 // Only meaningful in search mode, where a row is either a
                 // match or one of the ancestors dragged along with it.
                 isMatch: false,
+                // Subtree totals of the aggregated columns, keyed by field
+                // name, own value of the row included. False until the
+                // server answered, and for good when no column asks for a
+                // total.
+                aggregates: false,
             };
             return key;
         },
@@ -440,6 +461,64 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
         },
 
         /**
+         * Asks the server for the subtree total of every aggregated column
+         * of a whole level, in one single call for every id of that level
+         * rather than one call per node. A no-op when no column asks for a
+         * total, so a tree without ``sum=`` costs nothing extra.
+         *
+         * @private
+         * @param {Array} rowKeys the keys of one level of the tree
+         * @returns {Promise}
+         */
+        _fetchAggregates: function (rowKeys) {
+            if (!this.aggregateFieldNames.length || !rowKeys.length) {
+                return Promise.resolve();
+            }
+            const ids = rowKeys.map((key) => this.rows[key].id);
+            return this._rpc({
+                model: this.modelName,
+                method: "hierarchy_aggregate",
+                args: [ids, this.aggregateFieldNames],
+                kwargs: {
+                    parent_field: this.parentField || null,
+                    child_field: this.childField || null,
+                },
+                context: this.context,
+            }).then((totals) => {
+                for (const key of rowKeys) {
+                    const row = this.rows[key];
+                    // JSON turns the integer keys of the answer into
+                    // strings; indexing with the number reaches them all
+                    // the same.
+                    row.aggregates = totals[row.id] || false;
+                }
+            });
+        },
+
+        /**
+         * Adds up the subtree totals of the roots currently on screen,
+         * which is what the grand total row shows. Only the roots are
+         * summed: the total of a root already covers its whole subtree, so
+         * adding the descendants would count them twice.
+         *
+         * @private
+         */
+        _computeTotals: function () {
+            this.totals = {};
+            if (!this.aggregateFieldNames.length) {
+                return;
+            }
+            for (const name of this.aggregateFieldNames) {
+                let total = 0;
+                for (const key of this.rootKeys) {
+                    const aggregates = this.rows[key].aggregates;
+                    total += (aggregates && aggregates[name]) || 0;
+                }
+                this.totals[name] = total;
+            }
+        },
+
+        /**
          * @private
          * @param {Object} row
          * @returns {Promise}
@@ -480,6 +559,7 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
                 row.childKeys = ids
                     .filter((id) => byId[id])
                     .map((id) => this._registerRow(byId[id], row.key, row.level + 1));
+                return this._fetchAggregates(row.childKeys);
             });
         },
 
@@ -505,7 +585,9 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
                 row.childKeys = records.map((record) =>
                     this._registerRow(record, row.key, row.level + 1)
                 );
-                return this._computeHasChildren(row.childKeys);
+                return this._computeHasChildren(row.childKeys).then(() =>
+                    this._fetchAggregates(row.childKeys)
+                );
             });
         },
 

--- a/ssi_web_hierarchy_view/static/src/js/hierarchy_renderer.js
+++ b/ssi_web_hierarchy_view/static/src/js/hierarchy_renderer.js
@@ -16,6 +16,27 @@ odoo.define("ssi_web_hierarchy_view.HierarchyRenderer", function (require) {
     // Horizontal indentation added per hierarchy level, in pixels.
     const INDENT_PX = 20;
 
+    // Class carried by a cell showing a subtree total instead of the value
+    // of the record itself, so that a total can be told apart from a value
+    // and restyled by a database without touching this module.
+    const AGGREGATE_CLASS = "o_hierarchy_aggregate";
+
+    // The currency field a monetary field falls back to when it declares
+    // none of its own, the same fallback field_utils applies.
+    const DEFAULT_CURRENCY_FIELD = "currency_id";
+
+    /**
+     * @param {*} value a many2one value read by search_read/read, either
+     *      false or a [id, display_name] pair
+     * @returns {Number|Boolean} the id it carries, false when empty
+     */
+    function toId(value) {
+        if (Array.isArray(value)) {
+            return value.length ? value[0] : false;
+        }
+        return value || false;
+    }
+
     // Row decorations, in the order their classes are applied: a decoration
     // listed later wins over an earlier one whenever several of them light
     // up on the same row. The stylesheet declares them in this very order.
@@ -340,7 +361,9 @@ odoo.define("ssi_web_hierarchy_view.HierarchyRenderer", function (require) {
 
         /**
          * Formats one cell of a row for display, using the same formatters
-         * a list view uses.
+         * a list view uses. A column asking for a total shows the subtree
+         * total on a row that has children and the row's own value on a
+         * leaf.
          *
          * @param {Object} row
          * @param {Object} column
@@ -348,15 +371,162 @@ odoo.define("ssi_web_hierarchy_view.HierarchyRenderer", function (require) {
          */
         formatCell: function (row, column) {
             const field = this.fields[column.name];
-            const value = row.data[column.name];
             if (!field) {
                 return "";
             }
-            const formatter = field_utils.format[field.type];
-            if (formatter) {
-                return formatter(value, field);
+            return this._formatValue(this.cellValue(row, column), field, row.data);
+        },
+
+        /**
+         * @param {Object} row
+         * @param {Object} column
+         * @returns {*} the raw value the cell displays: the subtree total
+         *      on an aggregated parent row, the record's own value
+         *      everywhere else
+         */
+        cellValue: function (row, column) {
+            if (this.isAggregateCell(row, column)) {
+                return row.aggregates[column.name];
             }
-            return value === false || value === undefined ? "" : String(value);
+            return row.data[column.name];
+        },
+
+        /**
+         * A cell shows a total only on a row that actually has children:
+         * on a leaf the total would be the row's own value anyway, and
+         * showing it as a total would read as if something were summed
+         * underneath it.
+         *
+         * @param {Object} row
+         * @param {Object} column
+         * @returns {Boolean}
+         */
+        isAggregateCell: function (row, column) {
+            return Boolean(
+                column.sum &&
+                    row.hasChildren &&
+                    row.aggregates &&
+                    column.name in row.aggregates
+            );
+        },
+
+        /**
+         * @param {Object} row
+         * @param {Object} column
+         * @returns {String} the extra classes of a body cell
+         */
+        cellClass: function (row, column) {
+            return this.isAggregateCell(row, column) ? AGGREGATE_CLASS : "";
+        },
+
+        /**
+         * @returns {Boolean} whether a grand total row has to be drawn at
+         *      all, which is the case as soon as one column asks for a
+         *      total
+         */
+        hasTotals: function () {
+            return Object.keys(this.state.totals || {}).length > 0;
+        },
+
+        /**
+         * @param {Object} column
+         * @returns {Boolean} whether the grand total row holds a value in
+         *      that column
+         */
+        hasTotal: function (column) {
+            return Boolean(column.sum && column.name in (this.state.totals || {}));
+        },
+
+        /**
+         * @param {Object} column
+         * @returns {String} the extra classes of a grand total row cell
+         */
+        totalCellClass: function (column) {
+            return this.hasTotal(column) ? AGGREGATE_CLASS : "";
+        },
+
+        /**
+         * The label given to ``sum=`` becomes the tooltip of the grand
+         * total, the same way a list view uses it. ``undefined`` rather
+         * than ``false`` on a column without a total: QWeb only leaves an
+         * attribute out for ``undefined``/``null``, and would otherwise
+         * render ``title="false"``.
+         *
+         * @param {Object} column
+         * @returns {String|undefined}
+         */
+        totalTitle: function (column) {
+            return this.hasTotal(column) ? column.sum : undefined;
+        },
+
+        /**
+         * The grand total of one column: the sum over every root currently
+         * on screen, so it follows the active domain and the pager.
+         *
+         * @param {Object} column
+         * @returns {String}
+         */
+        formatTotal: function (column) {
+            if (!this.hasTotal(column)) {
+                return "";
+            }
+            const field = this.fields[column.name];
+            if (!field) {
+                return "";
+            }
+            return this._formatValue(
+                this.state.totals[column.name],
+                field,
+                this._totalRowData()
+            );
+        },
+
+        /**
+         * @private
+         * @returns {Object|Boolean} the values a monetary grand total
+         *      reads its currency from: those of the first root on
+         *      screen, every root of one page sharing one currency in
+         *      practice
+         */
+        _totalRowData: function () {
+            const rootKey = this.state.rootKeys[0];
+            const row = rootKey ? this.state.rows[rootKey] : false;
+            return row ? row.data : false;
+        },
+
+        /**
+         * @private
+         * @param {*} value
+         * @param {Object} field the field description of the column
+         * @param {Object|Boolean} data the values the row was read with,
+         *      needed by a monetary column to resolve its currency
+         * @returns {String}
+         */
+        _formatValue: function (value, field, data) {
+            const formatter = field_utils.format[field.type];
+            if (!formatter) {
+                return value === false || value === undefined ? "" : String(value);
+            }
+            return formatter(value, field, this._formatOptions(field, data));
+        },
+
+        /**
+         * A monetary value is formatted with the currency held by the
+         * ``currency_field`` the field declares itself, which the view
+         * fetches next to the column for that very reason.
+         *
+         * @private
+         * @param {Object} field the field description of the column
+         * @param {Object|Boolean} data the values the row was read with
+         * @returns {Object} the options handed to the formatter
+         */
+        _formatOptions: function (field, data) {
+            if (field.type !== "monetary" || !data) {
+                return {};
+            }
+            const currencyField = field.currency_field || DEFAULT_CURRENCY_FIELD;
+            const currencyId = toId(data[currencyField]);
+            return currencyId ? {currency_id: currencyId} : {};
         },
 
         /**

--- a/ssi_web_hierarchy_view/static/src/js/hierarchy_view.js
+++ b/ssi_web_hierarchy_view/static/src/js/hierarchy_view.js
@@ -37,6 +37,16 @@ odoo.define("ssi_web_hierarchy_view.HierarchyView", function (require) {
     const IDENTIFIER_RE = /[A-Za-z_]\w*/g;
     const STRING_LITERAL_RE = /'[^']*'|"[^"]*"/g;
 
+    // Field types a column may ask a subtree total for, exactly the ones a
+    // list view aggregates. The server rejects any other one when the view
+    // is saved; the same list is applied here so that an arch stored before
+    // that check existed cannot break the browser.
+    const AGGREGATABLE_TYPES = ["integer", "float", "monetary"];
+
+    // The currency field a monetary field falls back to when it declares
+    // none of its own, the same fallback field_utils applies.
+    const DEFAULT_CURRENCY_FIELD = "currency_id";
+
     const HierarchyView = AbstractView.extend({
         display_name: _lt("Hierarchy"),
         icon: "fa-sitemap",
@@ -83,6 +93,10 @@ odoo.define("ssi_web_hierarchy_view.HierarchyView", function (require) {
             this.loadParams.parentField = parentField;
             this.loadParams.defaultExpand = defaultExpand;
             this.loadParams.limit = limit;
+            this.loadParams.aggregateFieldNames = this._aggregateFieldNames(
+                columns,
+                fields
+            );
 
             this.withSearchPanel = false;
         },
@@ -99,7 +113,7 @@ odoo.define("ssi_web_hierarchy_view.HierarchyView", function (require) {
          *
          * @private
          * @param {Object} fields viewInfo.fields
-         * @returns {Array} [{name, label}]
+         * @returns {Array} [{name, label, sum}]
          */
         _buildColumns: function (fields) {
             const columns = [];
@@ -109,6 +123,10 @@ odoo.define("ssi_web_hierarchy_view.HierarchyView", function (require) {
                     columns.push({
                         name: child.attrs.name,
                         label: child.attrs.string || field.string || child.attrs.name,
+                        // The label of the grand total row, spelled the
+                        // same way a list view spells it. False when the
+                        // column asks for no total at all.
+                        sum: child.attrs.sum || false,
                     });
                 }
             }
@@ -116,12 +134,62 @@ odoo.define("ssi_web_hierarchy_view.HierarchyView", function (require) {
         },
 
         /**
+         * The columns whose subtree total the model has to ask the server
+         * for. A column asking for a total on a field the browser cannot
+         * aggregate is dropped rather than sent: the server would refuse
+         * the whole call and the tree would show nothing at all.
+         *
+         * @private
+         * @param {Array} columns
+         * @param {Object} fields viewInfo.fields
+         * @returns {Array} the names of the aggregated fields
+         */
+        _aggregateFieldNames: function (columns, fields) {
+            const names = [];
+            for (const column of columns) {
+                const field = fields[column.name];
+                if (!column.sum || !field) {
+                    continue;
+                }
+                if (AGGREGATABLE_TYPES.includes(field.type) && field.store) {
+                    names.push(column.name);
+                }
+            }
+            return _.uniq(names);
+        },
+
+        /**
+         * The currency fields the monetary totals are formatted with: the
+         * ``currency_field`` each monetary column declares itself. They
+         * are usually no column of the tree, so nothing else fetches them.
+         *
+         * @private
+         * @param {Array} columns
+         * @param {Object} fields viewInfo.fields
+         * @returns {Array}
+         */
+        _currencyFieldNames: function (columns, fields) {
+            const names = [];
+            for (const name of this._aggregateFieldNames(columns, fields)) {
+                const field = fields[name];
+                if (field.type !== "monetary") {
+                    continue;
+                }
+                const currencyField = field.currency_field || DEFAULT_CURRENCY_FIELD;
+                if (fields[currencyField]) {
+                    names.push(currencyField);
+                }
+            }
+            return names;
+        },
+
+        /**
          * Every field the tree reads has to be fetched by search_read/read:
          * the columns, plus ``child_field``/``parent_field`` themselves so
          * the model can tell whether a row has children and, in
          * ``child_field`` mode, read them without an extra search, plus the
-         * fields a decoration expression reads, which are usually no
-         * column at all.
+         * fields a decoration expression reads and the currency field of a
+         * monetary total, which are usually no column at all.
          *
          * @private
          * @param {Array} columns
@@ -142,6 +210,9 @@ odoo.define("ssi_web_hierarchy_view.HierarchyView", function (require) {
                 names.push(parentField);
             }
             for (const name of this._decorationFieldNames(fields)) {
+                names.push(name);
+            }
+            for (const name of this._currencyFieldNames(columns, fields)) {
                 names.push(name);
             }
             return _.uniq(names);

--- a/ssi_web_hierarchy_view/static/src/scss/hierarchy.scss
+++ b/ssi_web_hierarchy_view/static/src/scss/hierarchy.scss
@@ -101,6 +101,28 @@
     color: #adb5bd;
 }
 
+// A cell showing the total of a whole subtree instead of the value of the
+// record itself. Emphasised so that the number on a parent row cannot be
+// mistaken for a value that record carries on its own.
+.o_hierarchy_aggregate {
+    font-weight: bold;
+}
+
+// The grand total of every root currently on screen, drawn once at the very
+// bottom of the tree. The rule sits after the decoration classes so that it
+// is never tinted by a decoration of the arch.
+.o_hierarchy_total_row {
+    background-color: #f8f9fa;
+
+    > td {
+        border-top: 2px solid #dee2e6;
+    }
+}
+
+.o_hierarchy_total_label {
+    font-weight: bold;
+}
+
 .o_hierarchy_cell_main {
     display: flex;
     align-items: center;

--- a/ssi_web_hierarchy_view/static/src/xml/hierarchy.xml
+++ b/ssi_web_hierarchy_view/static/src/xml/hierarchy.xml
@@ -58,11 +58,34 @@
                             />
                         </td>
                         <t t-foreach="columns.slice(1)" t-as="column">
-                            <td t-esc="widget.formatCell(row, column)" />
+                            <td
+                                t-attf-class="#{widget.cellClass(row, column)}"
+                                t-esc="widget.formatCell(row, column)"
+                            />
                         </t>
                     </tr>
                 </t>
             </tbody>
+            <tfoot t-if="widget.hasTotals()" role="presentation">
+                <tr class="o_hierarchy_total_row">
+                    <td class="o_hierarchy_cell_main">
+                        <span class="o_hierarchy_total_label">Total</span>
+                        <span
+                            t-if="widget.hasTotal(columns[0])"
+                            class="o_hierarchy_label o_hierarchy_aggregate"
+                            t-att-title="widget.totalTitle(columns[0])"
+                            t-esc="widget.formatTotal(columns[0])"
+                        />
+                    </td>
+                    <t t-foreach="columns.slice(1)" t-as="column">
+                        <td
+                            t-attf-class="#{widget.totalCellClass(column)}"
+                            t-att-title="widget.totalTitle(column)"
+                            t-esc="widget.formatTotal(column)"
+                        />
+                    </t>
+                </tr>
+            </tfoot>
         </table>
     </t>
 

--- a/ssi_web_hierarchy_view/tests/test_data_ssi_web_hierarchy_view.yaml
+++ b/ssi_web_hierarchy_view/tests/test_data_ssi_web_hierarchy_view.yaml
@@ -391,6 +391,112 @@ scenarios:
           arch: |
             <hierarchy parent_field="parent_id" decoration-danger="not ==" />
 
+  - name: "ssi_web_hierarchy_view - sum on two numeric columns is accepted"
+    steps:
+      - step: "Create a view totalling an integer and a float column"
+        action: "create"
+        model: "ir.ui.view"
+        save_as: "view"
+        values:
+          name: "Partner Hierarchy Two Totals"
+          model: "res.partner"
+          type: "hierarchy"
+          arch: |
+            <hierarchy parent_field="parent_id">
+                <field name="name" />
+                <field name="color" sum="Total Color" />
+                <field name="credit_limit" sum="Total Credit Limit" />
+            </hierarchy>
+      - step: "Assert both sum attributes survived the arch validation"
+        action: "assert"
+        target: "view"
+        asserts:
+          type:
+            type: "value"
+            expected: "hierarchy"
+          arch_db:
+            type: "value"
+            operator: "contains"
+            expected: 'sum="Total Color"'
+      - step: "Assert the second sum attribute survived too"
+        action: "assert"
+        target: "view"
+        asserts:
+          arch_db:
+            type: "value"
+            operator: "contains"
+            expected: 'sum="Total Credit Limit"'
+
+  - name: "ssi_web_hierarchy_view - sum on a char column is rejected"
+    steps:
+      - step: "Create a view asking for the total of a char column"
+        action: "create"
+        model: "ir.ui.view"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "needs a numeric field"
+        values:
+          name: "Partner Hierarchy Sum On Char"
+          model: "res.partner"
+          type: "hierarchy"
+          arch: |
+            <hierarchy parent_field="parent_id">
+                <field name="name" sum="Total Name" />
+            </hierarchy>
+
+  - name: "ssi_web_hierarchy_view - sum on a date column is rejected"
+    steps:
+      - step: "Create a view asking for the total of a datetime column"
+        action: "create"
+        model: "ir.ui.view"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "needs a numeric field"
+        values:
+          name: "Partner Hierarchy Sum On Date"
+          model: "res.partner"
+          type: "hierarchy"
+          arch: |
+            <hierarchy parent_field="parent_id">
+                <field name="name" />
+                <field name="write_date" sum="Total Write Date" />
+            </hierarchy>
+
+  - name: "ssi_web_hierarchy_view - sum on a non stored column is rejected"
+    steps:
+      - step: "Create a view asking for the total of a computed column"
+        action: "create"
+        model: "ir.ui.view"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "needs a stored field"
+        values:
+          name: "Partner Hierarchy Sum Not Stored"
+          model: "res.partner"
+          type: "hierarchy"
+          arch: |
+            <hierarchy parent_field="parent_id">
+                <field name="name" />
+                <field name="active_lang_count" sum="Total Languages" />
+            </hierarchy>
+
+  - name: "ssi_web_hierarchy_view - sum on a column that does not exist is rejected"
+    steps:
+      - step: "Create a view asking for the total of an unknown column"
+        action: "create"
+        model: "ir.ui.view"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "does not exist"
+        values:
+          name: "Partner Hierarchy Sum Unknown Field"
+          model: "res.partner"
+          type: "hierarchy"
+          arch: |
+            <hierarchy parent_field="parent_id">
+                <field name="no_such_field_at_all" sum="Total Nothing" />
+            </hierarchy>
+
   - name: "ssi_web_hierarchy_view - Action view_mode accepts hierarchy"
     steps:
       - step: "Create a hierarchy view on res.partner"

--- a/ssi_web_hierarchy_view/tests/test_data_ssi_web_hierarchy_view.yaml
+++ b/ssi_web_hierarchy_view/tests/test_data_ssi_web_hierarchy_view.yaml
@@ -405,7 +405,7 @@ scenarios:
             <hierarchy parent_field="parent_id">
                 <field name="name" />
                 <field name="color" sum="Total Color" />
-                <field name="credit_limit" sum="Total Credit Limit" />
+                <field name="partner_latitude" sum="Total Latitude" />
             </hierarchy>
       - step: "Assert both sum attributes survived the arch validation"
         action: "assert"
@@ -425,7 +425,7 @@ scenarios:
           arch_db:
             type: "value"
             operator: "contains"
-            expected: 'sum="Total Credit Limit"'
+            expected: 'sum="Total Latitude"'
 
   - name: "ssi_web_hierarchy_view - sum on a char column is rejected"
     steps:

--- a/ssi_web_hierarchy_view/tests/test_ssi_web_hierarchy_view.py
+++ b/ssi_web_hierarchy_view/tests/test_ssi_web_hierarchy_view.py
@@ -38,9 +38,13 @@ class TestSsiWebHierarchyView(YamlTransactionCase):
     def _create_partner_amount_chain(self, prefix):
         """Create a three level ``res.partner`` chain carrying amounts.
 
-        ``color`` is an integer and ``credit_limit`` a float, both stored
-        on ``res.partner`` by ``base`` itself, so the totals can be
-        asserted without depending on any other module being installed.
+        ``color`` is an integer and ``partner_latitude`` a float, both
+        stored on ``res.partner`` by ``base`` itself, so the totals can
+        be asserted without depending on any other module being
+        installed. Neither of them is a commercial field, unlike
+        ``credit_limit``: Odoo copies a commercial field from the
+        commercial partner down to its children, which would give every
+        row of the chain one and the same value.
 
         :param prefix: prefix made unique per test, so that the domains
             of one test never match the records of another
@@ -51,7 +55,7 @@ class TestSsiWebHierarchyView(YamlTransactionCase):
             {
                 "name": "%s Grandparent" % prefix,
                 "color": 1,
-                "credit_limit": 10.5,
+                "partner_latitude": 10.5,
             }
         )
         parent = partner_model.create(
@@ -59,7 +63,7 @@ class TestSsiWebHierarchyView(YamlTransactionCase):
                 "name": "%s Parent" % prefix,
                 "parent_id": grandparent.id,
                 "color": 2,
-                "credit_limit": 20.25,
+                "partner_latitude": 20.25,
             }
         )
         child = partner_model.create(
@@ -67,7 +71,7 @@ class TestSsiWebHierarchyView(YamlTransactionCase):
                 "name": "%s Child" % prefix,
                 "parent_id": parent.id,
                 "color": 4,
-                "credit_limit": 30.125,
+                "partner_latitude": 30.125,
             }
         )
         return grandparent, parent, child
@@ -284,11 +288,13 @@ class TestSsiWebHierarchyView(YamlTransactionCase):
         )
         totals = self.env["res.partner"].hierarchy_aggregate(
             [grandparent.id],
-            ["color", "credit_limit"],
+            ["color", "partner_latitude"],
             parent_field="parent_id",
         )
         self.assertEqual(totals[grandparent.id]["color"], 7)
-        self.assertAlmostEqual(totals[grandparent.id]["credit_limit"], 60.875, places=3)
+        self.assertAlmostEqual(
+            totals[grandparent.id]["partner_latitude"], 60.875, places=3
+        )
         self.assertNotIn(parent.id, totals)
         self.assertNotIn(child.id, totals)
 
@@ -302,11 +308,11 @@ class TestSsiWebHierarchyView(YamlTransactionCase):
         child = self._create_partner_amount_chain("SSIWHV Aggregate Leaf")[2]
         totals = self.env["res.partner"].hierarchy_aggregate(
             [child.id],
-            ["color", "credit_limit"],
+            ["color", "partner_latitude"],
             parent_field="parent_id",
         )
         self.assertEqual(totals[child.id]["color"], 4)
-        self.assertAlmostEqual(totals[child.id]["credit_limit"], 30.125, places=3)
+        self.assertAlmostEqual(totals[child.id]["partner_latitude"], 30.125, places=3)
 
     def test_aggregate_answers_every_id_of_one_call(self):
         """Assert one call covers a whole level rather than one node.
@@ -342,12 +348,12 @@ class TestSsiWebHierarchyView(YamlTransactionCase):
         partner_model = self.env["res.partner"]
         by_parent = partner_model.hierarchy_aggregate(
             [grandparent.id],
-            ["color", "credit_limit"],
+            ["color", "partner_latitude"],
             parent_field="parent_id",
         )
         by_child = partner_model.hierarchy_aggregate(
             [grandparent.id],
-            ["color", "credit_limit"],
+            ["color", "partner_latitude"],
             child_field="child_ids",
         )
         self.assertEqual(
@@ -355,12 +361,12 @@ class TestSsiWebHierarchyView(YamlTransactionCase):
             by_child[grandparent.id]["color"],
         )
         self.assertAlmostEqual(
-            by_parent[grandparent.id]["credit_limit"],
-            by_child[grandparent.id]["credit_limit"],
+            by_parent[grandparent.id]["partner_latitude"],
+            by_child[grandparent.id]["partner_latitude"],
             places=3,
         )
         self.assertAlmostEqual(
-            by_child[grandparent.id]["credit_limit"], 60.875, places=3
+            by_child[grandparent.id]["partner_latitude"], 60.875, places=3
         )
 
     def test_aggregate_rejects_an_unknown_field(self):

--- a/ssi_web_hierarchy_view/tests/test_ssi_web_hierarchy_view.py
+++ b/ssi_web_hierarchy_view/tests/test_ssi_web_hierarchy_view.py
@@ -10,11 +10,12 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestSsiWebHierarchyView(YamlTransactionCase):
-    """Covers the ``hierarchy`` view type arch validation and the search.
+    """Covers the ``hierarchy`` view arch validation, search and totals.
 
     The arch validation scenarios live in the YAML file; the hierarchical
-    search is asserted here because what is under test is the value
-    ``hierarchy_search_ancestors`` returns.
+    search and the subtree totals are asserted here because what is under
+    test is the value ``hierarchy_search_ancestors`` and
+    ``hierarchy_aggregate`` return.
     """
 
     def _create_partner_chain(self, prefix):
@@ -31,6 +32,43 @@ class TestSsiWebHierarchyView(YamlTransactionCase):
         )
         child = partner_model.create(
             {"name": "%s Child" % prefix, "parent_id": parent.id}
+        )
+        return grandparent, parent, child
+
+    def _create_partner_amount_chain(self, prefix):
+        """Create a three level ``res.partner`` chain carrying amounts.
+
+        ``color`` is an integer and ``credit_limit`` a float, both stored
+        on ``res.partner`` by ``base`` itself, so the totals can be
+        asserted without depending on any other module being installed.
+
+        :param prefix: prefix made unique per test, so that the domains
+            of one test never match the records of another
+        :return: tuple of the grandparent, the parent and the child
+        """
+        partner_model = self.env["res.partner"]
+        grandparent = partner_model.create(
+            {
+                "name": "%s Grandparent" % prefix,
+                "color": 1,
+                "credit_limit": 10.5,
+            }
+        )
+        parent = partner_model.create(
+            {
+                "name": "%s Parent" % prefix,
+                "parent_id": grandparent.id,
+                "color": 2,
+                "credit_limit": 20.25,
+            }
+        )
+        child = partner_model.create(
+            {
+                "name": "%s Child" % prefix,
+                "parent_id": parent.id,
+                "color": 4,
+                "credit_limit": 30.125,
+            }
         )
         return grandparent, parent, child
 
@@ -226,5 +264,180 @@ class TestSsiWebHierarchyView(YamlTransactionCase):
         with self.assertRaises(UserError) as error:
             self.env["res.partner"].hierarchy_search_ancestors(
                 [("id", "=", child.id)], "parent_id"
+            )
+        self.assertIn("nested deeper than 64 levels", str(error.exception))
+
+    def test_aggregate_totals_the_whole_subtree(self):
+        """Assert a grandparent total covers its children and grandchildren.
+
+        The total of a parent has to include the value of the parent
+        itself, otherwise it no longer equals the sum of the column as it
+        is displayed underneath it.
+
+        Pure Python — trigger P1 (L-01: the ``call`` action discards the
+        return value of a method, and L-02 only lets an assert reach a
+        field of a record, never a returned dict) and trigger P2 (L-04:
+        there is no float tolerance in YAML).
+        """
+        grandparent, parent, child = self._create_partner_amount_chain(
+            "SSIWHV Aggregate"
+        )
+        totals = self.env["res.partner"].hierarchy_aggregate(
+            [grandparent.id],
+            ["color", "credit_limit"],
+            parent_field="parent_id",
+        )
+        self.assertEqual(totals[grandparent.id]["color"], 7)
+        self.assertAlmostEqual(totals[grandparent.id]["credit_limit"], 60.875, places=3)
+        self.assertNotIn(parent.id, totals)
+        self.assertNotIn(child.id, totals)
+
+    def test_aggregate_of_a_leaf_is_its_own_value(self):
+        """Assert a leaf reports the value it carries itself.
+
+        Pure Python — trigger P1 (L-01: the ``call`` action discards the
+        return value of a method) and trigger P2 (L-04: there is no float
+        tolerance in YAML).
+        """
+        child = self._create_partner_amount_chain("SSIWHV Aggregate Leaf")[2]
+        totals = self.env["res.partner"].hierarchy_aggregate(
+            [child.id],
+            ["color", "credit_limit"],
+            parent_field="parent_id",
+        )
+        self.assertEqual(totals[child.id]["color"], 4)
+        self.assertAlmostEqual(totals[child.id]["credit_limit"], 30.125, places=3)
+
+    def test_aggregate_answers_every_id_of_one_call(self):
+        """Assert one call covers a whole level rather than one node.
+
+        The view aggregates a level in a single call, so every id handed
+        over has to come back with its own total.
+
+        Pure Python — trigger P1 (L-01: the ``call`` action discards the
+        return value of a method, and L-02 only lets an assert reach a
+        field of a record, never a returned dict).
+        """
+        grandparent, parent, child = self._create_partner_amount_chain(
+            "SSIWHV Aggregate Batch"
+        )
+        totals = self.env["res.partner"].hierarchy_aggregate(
+            [grandparent.id, parent.id, child.id],
+            ["color"],
+            parent_field="parent_id",
+        )
+        self.assertEqual(set(totals), {grandparent.id, parent.id, child.id})
+        self.assertEqual(totals[grandparent.id]["color"], 7)
+        self.assertEqual(totals[parent.id]["color"], 6)
+        self.assertEqual(totals[child.id]["color"], 4)
+
+    def test_aggregate_by_parent_field_and_by_child_field_match(self):
+        """Assert both ways of walking the tree report the same totals.
+
+        Pure Python — trigger P1 (L-01: the ``call`` action discards the
+        return value of a method) and trigger P2 (L-04: there is no float
+        tolerance in YAML).
+        """
+        grandparent = self._create_partner_amount_chain("SSIWHV Aggregate Both")[0]
+        partner_model = self.env["res.partner"]
+        by_parent = partner_model.hierarchy_aggregate(
+            [grandparent.id],
+            ["color", "credit_limit"],
+            parent_field="parent_id",
+        )
+        by_child = partner_model.hierarchy_aggregate(
+            [grandparent.id],
+            ["color", "credit_limit"],
+            child_field="child_ids",
+        )
+        self.assertEqual(
+            by_parent[grandparent.id]["color"],
+            by_child[grandparent.id]["color"],
+        )
+        self.assertAlmostEqual(
+            by_parent[grandparent.id]["credit_limit"],
+            by_child[grandparent.id]["credit_limit"],
+            places=3,
+        )
+        self.assertAlmostEqual(
+            by_child[grandparent.id]["credit_limit"], 60.875, places=3
+        )
+
+    def test_aggregate_rejects_an_unknown_field(self):
+        """Reject a total asked for on a field that does not exist.
+
+        Pure Python — trigger P1 (L-01: the method is called for its
+        return value, and L-02 keeps YAML asserts on record fields, so
+        the guard cannot be reached declaratively).
+        """
+        with self.assertRaises(UserError) as error:
+            self.env["res.partner"].hierarchy_aggregate(
+                [], ["no_such_field_at_all"], parent_field="parent_id"
+            )
+        self.assertIn("no_such_field_at_all", str(error.exception))
+        self.assertIn("does not exist", str(error.exception))
+
+    def test_aggregate_rejects_a_non_numeric_field(self):
+        """Reject a total asked for on a field that is not numeric.
+
+        Pure Python — trigger P1 (L-01: the method is called for its
+        return value, and L-02 keeps YAML asserts on record fields, so
+        the guard cannot be reached declaratively).
+        """
+        with self.assertRaises(UserError) as error:
+            self.env["res.partner"].hierarchy_aggregate(
+                [], ["name"], parent_field="parent_id"
+            )
+        self.assertIn("is not a numeric field", str(error.exception))
+
+    def test_aggregate_rejects_a_field_that_is_not_stored(self):
+        """Reject a total asked for on a field that is not stored.
+
+        A total is built from a query, so a computed column that lives
+        nowhere in the database cannot be summed at all.
+
+        Pure Python — trigger P1 (L-01: the method is called for its
+        return value, and L-02 keeps YAML asserts on record fields, so
+        the guard cannot be reached declaratively).
+        """
+        with self.assertRaises(UserError) as error:
+            self.env["res.partner"].hierarchy_aggregate(
+                [], ["active_lang_count"], parent_field="parent_id"
+            )
+        self.assertIn("is not stored", str(error.exception))
+
+    def test_aggregate_rejects_a_missing_walk_field(self):
+        """Reject an aggregation that cannot reach any descendant.
+
+        Pure Python — trigger P1 (L-01: the method is called for its
+        return value, and L-02 keeps YAML asserts on record fields, so
+        the guard cannot be reached declaratively).
+        """
+        with self.assertRaises(UserError) as error:
+            self.env["res.partner"].hierarchy_aggregate([], ["color"])
+        self.assertIn("Neither parent_field nor child_field", str(error.exception))
+
+    def test_aggregate_rejects_cyclic_data(self):
+        """Reject a subtree walk that never reaches a leaf record.
+
+        Pure Python — trigger P1 (L-01: the method is called for its
+        return value) combined with the raw SQL needed to produce the
+        cycle: ``res.partner._check_parent_id`` makes a cycle unwritable
+        through the ORM, and YAML has no way to bypass a constraint
+        (L-02).
+        """
+        root = self.env["res.partner"].create({"name": "SSIWHV Agg Cycle Root"})
+        child = self.env["res.partner"].create(
+            {"name": "SSIWHV Agg Cycle Child", "parent_id": root.id}
+        )
+        self.env["res.partner"].flush()
+        self.env.cr.execute(
+            "UPDATE res_partner SET parent_id = %s WHERE id = %s",
+            (child.id, root.id),
+        )
+        self.env["res.partner"].invalidate_cache()
+        with self.assertRaises(UserError) as error:
+            self.env["res.partner"].hierarchy_aggregate(
+                [root.id], ["color"], parent_field="parent_id"
             )
         self.assertIn("nested deeper than 64 levels", str(error.exception))


### PR DESCRIPTION
Closes #82

## Ringkasan

Kolom numerik ber-`sum=` pada view `hierarchy` sekarang menampilkan total
seluruh subpohon di setiap baris induk, plus baris total keseluruhan di
paling bawah.

## Perubahan

**`models/ir_ui_view.py`** — validasi atribut `sum="<label>"` pada `<field>`
di dalam `_postprocess_tag_hierarchy`, memakai mekanisme `handle_view_error`
yang sudah dipakai validasi `decoration-*`:

* hanya field bertipe `integer`/`float`/`monetary` yang diterima;
* field numerik yang **tidak** `store` ditolak — total dihitung server-side
  lewat query;
* field `currency_field` milik kolom monetary ikut didaftarkan ke name
  manager agar diambil browser.

**`models/base.py`** — method publik baru pada `_inherit = "base"`:

* `hierarchy_aggregate(node_ids, field_names, parent_field=None,
  child_field=None)` → `{node_id: {field_name: total}}`, satu entri untuk
  setiap id yang diminta;
* total baris induk **termasuk nilai baris itu sendiri**;
* penelusuran keturunan breadth-first, **satu query per level** (bukan satu
  per node), lewat `parent_field` bila ada dan `child_field` bila tidak;
  `child_of` sengaja tidak dipakai karena mensyaratkan field itu
  `_parent_name` model;
* tanpa `sudo()` — keturunan yang tak boleh dibaca user tidak ikut
  dijumlahkan;
* konstanta `HIERARCHY_MAX_DEPTH = 64` yang sudah ada dipakai ulang, jadi
  hirarki siklik memicu `UserError` berformat SSI, bukan hang.

**Sisi browser** (`hierarchy_view.js`, `hierarchy_model.js`,
`hierarchy_renderer.js`, `hierarchy.xml`, `hierarchy.scss`):

* model memanggil `hierarchy_aggregate` sekali per level saat node dibuka;
* baris induk menampilkan total subpohon dengan kelas
  `o_hierarchy_aggregate`, baris daun tetap menampilkan nilai aslinya tanpa
  kelas agregat;
* baris total keseluruhan digambar di `<tfoot>`, menjumlahkan agregat
  seluruh akar yang sedang tampil sehingga ikut domain & pager aktif, dengan
  label `sum=` sebagai tooltip;
* pembulatan & format mengikuti field: `digits` untuk float, `currency_field`
  yang dideklarasikan field itu sendiri untuk monetary.

## Test

* **9 test Python baru** — nilai balik `hierarchy_aggregate` (kriteria P1)
  dan perbandingan angka dengan toleransi float (kriteria P2): total tiga
  tingkat, total baris daun, beberapa id dalam satu panggilan, `parent_field`
  vs `child_field` menghasilkan angka identik, penolakan field tak dikenal /
  non-numerik / non-`store` / tanpa field penelusuran, dan hirarki siklik.
* **5 skenario `odoo-yaml-test` baru** — `sum=` pada dua kolom numerik
  diterima; `sum=` pada `char`, `datetime`, field non-`store`, dan field yang
  tidak ada ditolak dengan `ValidationError`.
* Tidak ada test, assertion, atau import di `tests/__init__.py` yang dihapus,
  di-skip, atau dilonggarkan.

`README.rst` diperbarui: bagian *Numeric column totals* ditambahkan dan
batasan "No numeric column aggregation (`sum=`)" dihapus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)