### PR TITLE
[UPD] ssi_web_hierarchy_view: cegah descendant terhitung ganda di grand total

### DIFF
--- a/ssi_web_hierarchy_view/README.rst
+++ b/ssi_web_hierarchy_view/README.rst
@@ -100,14 +100,18 @@ the very bottom of the tree::
 * A cell showing a total carries the class ``o_hierarchy_aggregate``, so a
   total can be told apart from a plain value and restyled by a database
   without touching this module.
-* The **grand total row** adds up the subtree totals of the roots currently
-  on screen, so it follows the active domain and the active page of the
-  pager. The label given to ``sum=`` is its tooltip.
-* In a ``child_field``-only view every record matching the domain is a root
-  (see *Determining the hierarchy*), so the grand total adds up subtree
-  totals that overlap and a descendant is counted once per ancestor of it on
-  screen. Add ``parent_field`` next to ``child_field`` to get a grand total
-  that counts every record exactly once.
+* The **grand total row** totals the union of the subtrees of the roots
+  currently on screen, so it follows the active domain and the active page of
+  the pager. The label given to ``sum=`` is its tooltip.
+* Every record is counted **exactly once** in the grand total, however many
+  of its ancestors are on screen. This matters in a ``child_field``-only
+  view, where every record matching the domain is a root (see *Determining
+  the hierarchy*) and the subtrees of the rows therefore overlap: the grand
+  total there is deliberately **not** the sum of the column as it is
+  displayed, precisely because the displayed values overlap each other.
+* The grand total does **not** change when a node is opened or closed:
+  opening a node adds no root, and the total already covers every descendant
+  of the roots whether they are visible or not.
 * Rounding and formatting follow the field itself: ``digits`` for a float, and
   for a ``monetary`` column the currency named by the ``currency_field`` that
   field declares — the view fetches that currency field next to the column
@@ -125,6 +129,19 @@ not used, since it would require the walked field to be the model's
 descendant the user may not read is left out of the total, consistently with
 the rows that user sees. A tree nested deeper than 64 levels is treated as
 cyclic data and raises, rather than looping forever.
+
+The grand total row is computed by ``hierarchy_grand_total(node_ids,
+field_names, parent_field=None, child_field=None)``, a second method this
+module adds to every model. It merges the subtrees of ``node_ids`` into one
+single set of ids before summing, and returns ``{field_name: total}`` with
+one entry per given name — ``0`` for every name when ``node_ids`` is empty.
+That merge is what makes a record count exactly once even when several of
+its ancestors are on screen; it validates its fields, walks the tree and
+honours access rights exactly like ``hierarchy_aggregate``, so a grand total
+over one single root equals the total that method reports for that root. It
+is called only when the set of roots changes — first load, new domain, new
+page of the pager, entering or leaving search mode — never when a node is
+opened.
 
 Row decorations
 ---------------

--- a/ssi_web_hierarchy_view/models/base.py
+++ b/ssi_web_hierarchy_view/models/base.py
@@ -25,8 +25,10 @@ class Base(models.AbstractModel):
     Adds the server side of the hierarchy view to every model: one single
     call returns the records matching a domain together with their whole
     parent chain, so that the browser never has to walk that chain with
-    one RPC per level, and one single call returns the subtree total of a
-    numeric column for a whole level of nodes at once.
+    one RPC per level, one single call returns the subtree total of a
+    numeric column for a whole level of nodes at once, and one single call
+    returns the grand total of a numeric column over a whole set of nodes,
+    counting every record of it exactly once.
     """
 
     _inherit = "base"
@@ -218,6 +220,53 @@ Solution: Break the parent loop in the data of model %s
                 for field_name in field_names
             }
         return totals
+
+    def hierarchy_grand_total(
+        self, node_ids, field_names, parent_field=None, child_field=None
+    ):
+        """Return the total of every field over the union of the subtrees.
+
+        Called by the ``hierarchy`` view for its grand total row, once per
+        change of the set of nodes on screen. Adding up the subtree totals
+        of those nodes in the browser would be wrong as soon as one of
+        them is a descendant of another one, which is exactly what happens
+        in a ``child_field``-only view, where every record matching the
+        domain is a root: the descendant would then be counted once per
+        ancestor of it on screen. Here the subtrees are merged into one
+        single set of ids first, so every record is read once and summed
+        once, however many of its ancestors are on screen.
+
+        Descendants are walked, fields are validated and access rights are
+        honoured exactly like in :meth:`hierarchy_aggregate` — the two
+        methods share every helper — so a total over one single root
+        equals the total that method reports for that root.
+
+        :param node_ids: ids of the nodes whose subtrees are totalled,
+            an empty list totalling nothing at all
+        :param field_names: names of the numeric stored fields to total
+        :param parent_field: name of the ``many2one`` to this same model
+            carrying the parent of a record, ``None`` to walk
+            ``child_field`` instead
+        :param child_field: name of the ``one2many``/``many2many`` to
+            this same model carrying the children of a record, used only
+            when ``parent_field`` is not given
+        :return: dict ``{field_name: total}`` holding one entry for every
+            name of ``field_names``, the total being ``0`` when
+            ``node_ids`` is empty
+        :raises UserError: when a field of ``field_names`` does not
+            exist, is not numeric or is not stored, when neither
+            ``parent_field`` nor ``child_field`` is given, or when the
+            tree is nested deeper than ``HIERARCHY_MAX_DEPTH`` levels,
+            which only happens on cyclic data
+        """
+        self._check_hierarchy_aggregate_fields(field_names)
+        self._check_hierarchy_walk_fields(parent_field, child_field)
+        subtree_ids = self._hierarchy_subtree_ids(node_ids, parent_field, child_field)
+        values = self._hierarchy_aggregate_values(subtree_ids, field_names)
+        return {
+            field_name: sum(record.get(field_name) or 0 for record in values.values())
+            for field_name in field_names
+        }
 
     def _check_hierarchy_aggregate_fields(self, field_names):
         """Reject a field that carries no summable stored value.

--- a/ssi_web_hierarchy_view/static/src/js/hierarchy_model.js
+++ b/ssi_web_hierarchy_view/static/src/js/hierarchy_model.js
@@ -44,9 +44,10 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
             this.limitReached = false;
             this.searchMode = false;
             this.searchTruncated = false;
-            // Grand totals of the aggregated columns over the roots on
-            // screen, keyed by field name. Empty when no column asks for
-            // a total at all.
+            // Grand totals of the aggregated columns over the union of
+            // the subtrees of the roots on screen, keyed by field name,
+            // every record counted exactly once. Computed server side.
+            // Empty when no column asks for a total at all.
             this.totals = {};
         },
 
@@ -496,26 +497,49 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
         },
 
         /**
-         * Adds up the subtree totals of the roots currently on screen,
-         * which is what the grand total row shows. Only the roots are
-         * summed: the total of a root already covers its whole subtree, so
-         * adding the descendants would count them twice.
+         * Asks the server for the grand total row: the total of every
+         * aggregated column over the union of the subtrees of the roots
+         * currently on screen, every record counted exactly once.
+         *
+         * Adding up the subtree totals of the roots here instead would be
+         * wrong as soon as one root is a descendant of another one, which
+         * is exactly what a ``child_field``-only view produces, since
+         * every record matching the domain is a root there. The server
+         * merges the subtrees before summing, so the deduplication cannot
+         * be skipped by the browser.
+         *
+         * Called only when the set of roots changes — first load, new
+         * domain, new page of the pager, entering or leaving search mode.
+         * Opening a node leaves the roots untouched and therefore leaves
+         * the grand total untouched too, so it costs no call at all.
          *
          * @private
+         * @returns {Promise}
          */
         _computeTotals: function () {
             this.totals = {};
             if (!this.aggregateFieldNames.length) {
-                return;
+                return Promise.resolve();
             }
-            for (const name of this.aggregateFieldNames) {
-                let total = 0;
-                for (const key of this.rootKeys) {
-                    const aggregates = this.rows[key].aggregates;
-                    total += (aggregates && aggregates[name]) || 0;
+            const ids = this.rootKeys.map((key) => this.rows[key].id);
+            if (!ids.length) {
+                for (const name of this.aggregateFieldNames) {
+                    this.totals[name] = 0;
                 }
-                this.totals[name] = total;
+                return Promise.resolve();
             }
+            return this._rpc({
+                model: this.modelName,
+                method: "hierarchy_grand_total",
+                args: [ids, this.aggregateFieldNames],
+                kwargs: {
+                    parent_field: this.parentField || null,
+                    child_field: this.childField || null,
+                },
+                context: this.context,
+            }).then((totals) => {
+                this.totals = totals;
+            });
         },
 
         /**

--- a/ssi_web_hierarchy_view/static/src/js/hierarchy_renderer.js
+++ b/ssi_web_hierarchy_view/static/src/js/hierarchy_renderer.js
@@ -460,8 +460,9 @@ odoo.define("ssi_web_hierarchy_view.HierarchyRenderer", function (require) {
         },
 
         /**
-         * The grand total of one column: the sum over every root currently
-         * on screen, so it follows the active domain and the pager.
+         * The grand total of one column: the total over the union of the
+         * subtrees of the roots currently on screen, every record counted
+         * exactly once, so it follows the active domain and the pager.
          *
          * @param {Object} column
          * @returns {String}

--- a/ssi_web_hierarchy_view/tests/test_ssi_web_hierarchy_view.py
+++ b/ssi_web_hierarchy_view/tests/test_ssi_web_hierarchy_view.py
@@ -13,9 +13,10 @@ class TestSsiWebHierarchyView(YamlTransactionCase):
     """Covers the ``hierarchy`` view arch validation, search and totals.
 
     The arch validation scenarios live in the YAML file; the hierarchical
-    search and the subtree totals are asserted here because what is under
-    test is the value ``hierarchy_search_ancestors`` and
-    ``hierarchy_aggregate`` return.
+    search, the subtree totals and the grand total are asserted here
+    because what is under test is the value
+    ``hierarchy_search_ancestors``, ``hierarchy_aggregate`` and
+    ``hierarchy_grand_total`` return.
     """
 
     def _create_partner_chain(self, prefix):
@@ -444,6 +445,171 @@ class TestSsiWebHierarchyView(YamlTransactionCase):
         self.env["res.partner"].invalidate_cache()
         with self.assertRaises(UserError) as error:
             self.env["res.partner"].hierarchy_aggregate(
+                [root.id], ["color"], parent_field="parent_id"
+            )
+        self.assertIn("nested deeper than 64 levels", str(error.exception))
+
+    def test_grand_total_of_one_root_equals_its_subtree_total(self):
+        """Assert the grand total of a lone root equals its own total.
+
+        The grand total row and a parent row have to agree with each
+        other whenever there is nothing to deduplicate, otherwise the two
+        methods would be reporting two different hierarchies.
+
+        Pure Python — trigger P1 (L-01: the ``call`` action discards the
+        return value of a method, and L-02 only lets an assert reach a
+        field of a record, never a returned dict) and trigger P2 (L-04:
+        there is no float tolerance in YAML).
+        """
+        grandparent = self._create_partner_amount_chain("SSIWHV Grand One")[0]
+        partner_model = self.env["res.partner"]
+        totals = partner_model.hierarchy_grand_total(
+            [grandparent.id],
+            ["color", "partner_latitude"],
+            parent_field="parent_id",
+        )
+        subtree = partner_model.hierarchy_aggregate(
+            [grandparent.id],
+            ["color", "partner_latitude"],
+            parent_field="parent_id",
+        )
+        self.assertEqual(totals["color"], subtree[grandparent.id]["color"])
+        self.assertAlmostEqual(
+            totals["partner_latitude"],
+            subtree[grandparent.id]["partner_latitude"],
+            places=3,
+        )
+        self.assertEqual(totals["color"], 7)
+        self.assertAlmostEqual(totals["partner_latitude"], 60.875, places=3)
+
+    def test_grand_total_counts_a_descendant_only_once(self):
+        """Assert overlapping subtrees do not inflate the grand total.
+
+        This is the regression lock of the whole method: handing over a
+        grandparent, its child and its grandchild at once is exactly what
+        a ``child_field``-only view does, since every record matching the
+        domain is a root there. Summing the three subtree totals in the
+        browser would count the grandchild three times and the child
+        twice; the total has to stay the one of the grandparent alone.
+
+        Pure Python — trigger P1 (L-01: the ``call`` action discards the
+        return value of a method, and L-02 only lets an assert reach a
+        field of a record, never a returned dict) and trigger P2 (L-04:
+        there is no float tolerance in YAML).
+        """
+        grandparent, parent, child = self._create_partner_amount_chain(
+            "SSIWHV Grand Overlap"
+        )
+        totals = self.env["res.partner"].hierarchy_grand_total(
+            [grandparent.id, parent.id, child.id],
+            ["color", "partner_latitude"],
+            parent_field="parent_id",
+        )
+        self.assertEqual(totals["color"], 7)
+        self.assertAlmostEqual(totals["partner_latitude"], 60.875, places=3)
+
+    def test_grand_total_of_no_node_is_zero_per_field(self):
+        """Assert an empty node list still answers every asked field.
+
+        The browser draws a grand total row as soon as a column asks for
+        a total, so an empty page has to report ``0`` rather than a dict
+        holding nothing at all.
+
+        Pure Python — trigger P1 (L-01: the ``call`` action discards the
+        return value of a method, and L-02 only lets an assert reach a
+        field of a record, never a returned dict).
+        """
+        totals = self.env["res.partner"].hierarchy_grand_total(
+            [], ["color", "partner_latitude"], parent_field="parent_id"
+        )
+        self.assertEqual(set(totals), {"color", "partner_latitude"})
+        self.assertEqual(totals["color"], 0)
+        self.assertEqual(totals["partner_latitude"], 0)
+
+    def test_grand_total_by_parent_field_and_by_child_field_match(self):
+        """Assert both ways of walking the tree report one same total.
+
+        Pure Python — trigger P1 (L-01: the ``call`` action discards the
+        return value of a method) and trigger P2 (L-04: there is no float
+        tolerance in YAML).
+        """
+        grandparent, parent, child = self._create_partner_amount_chain(
+            "SSIWHV Grand Both"
+        )
+        node_ids = [grandparent.id, parent.id, child.id]
+        partner_model = self.env["res.partner"]
+        by_parent = partner_model.hierarchy_grand_total(
+            node_ids, ["color", "partner_latitude"], parent_field="parent_id"
+        )
+        by_child = partner_model.hierarchy_grand_total(
+            node_ids, ["color", "partner_latitude"], child_field="child_ids"
+        )
+        self.assertEqual(by_parent["color"], by_child["color"])
+        self.assertAlmostEqual(
+            by_parent["partner_latitude"],
+            by_child["partner_latitude"],
+            places=3,
+        )
+        self.assertAlmostEqual(by_child["partner_latitude"], 60.875, places=3)
+
+    def test_grand_total_rejects_a_non_numeric_field(self):
+        """Reject a grand total asked for on a field that is not numeric.
+
+        Pure Python — trigger P1 (L-01: the method is called for its
+        return value, and L-02 keeps YAML asserts on record fields, so
+        the guard cannot be reached declaratively).
+        """
+        with self.assertRaises(UserError) as error:
+            self.env["res.partner"].hierarchy_grand_total(
+                [], ["name"], parent_field="parent_id"
+            )
+        self.assertIn("is not a numeric field", str(error.exception))
+
+    def test_grand_total_rejects_a_field_that_is_not_stored(self):
+        """Reject a grand total asked for on a field that is not stored.
+
+        Pure Python — trigger P1 (L-01: the method is called for its
+        return value, and L-02 keeps YAML asserts on record fields, so
+        the guard cannot be reached declaratively).
+        """
+        with self.assertRaises(UserError) as error:
+            self.env["res.partner"].hierarchy_grand_total(
+                [], ["active_lang_count"], parent_field="parent_id"
+            )
+        self.assertIn("is not stored", str(error.exception))
+
+    def test_grand_total_rejects_a_missing_walk_field(self):
+        """Reject a grand total that cannot reach any descendant.
+
+        Pure Python — trigger P1 (L-01: the method is called for its
+        return value, and L-02 keeps YAML asserts on record fields, so
+        the guard cannot be reached declaratively).
+        """
+        with self.assertRaises(UserError) as error:
+            self.env["res.partner"].hierarchy_grand_total([], ["color"])
+        self.assertIn("Neither parent_field nor child_field", str(error.exception))
+
+    def test_grand_total_rejects_cyclic_data(self):
+        """Reject a grand total walk that never reaches a leaf record.
+
+        Pure Python — trigger P1 (L-01: the method is called for its
+        return value) combined with the raw SQL needed to produce the
+        cycle: ``res.partner._check_parent_id`` makes a cycle unwritable
+        through the ORM, and YAML has no way to bypass a constraint
+        (L-02).
+        """
+        root = self.env["res.partner"].create({"name": "SSIWHV Grand Cycle Root"})
+        child = self.env["res.partner"].create(
+            {"name": "SSIWHV Grand Cycle Child", "parent_id": root.id}
+        )
+        self.env["res.partner"].flush()
+        self.env.cr.execute(
+            "UPDATE res_partner SET parent_id = %s WHERE id = %s",
+            (child.id, root.id),
+        )
+        self.env["res.partner"].invalidate_cache()
+        with self.assertRaises(UserError) as error:
+            self.env["res.partner"].hierarchy_grand_total(
                 [root.id], ["color"], parent_field="parent_id"
             )
         self.assertIn("nested deeper than 64 levels", str(error.exception))


### PR DESCRIPTION
Closes #91

## Masalah

Baris grand total dihitung di browser oleh `_computeTotals()` dengan menjumlahkan `row.aggregates[name]` atas seluruh `rootKeys`, sementara tiap `aggregates` adalah total **seluruh subpohon** node itu. Pada view yang hanya punya `child_field`, `_rootDomain()` tidak menambahkan filter `[parent_field, "=", False]`, sehingga **setiap** record yang cocok domain menjadi root. Akibatnya satu descendant terhitung sekali untuk **setiap** leluhurnya yang juga tampil di layar, dan grand total membengkak berkali-kali lipat tanpa tanda apa pun bagi pembaca.

## Perubahan

* **`models/base.py`** — method publik baru `hierarchy_grand_total(node_ids, field_names, parent_field=None, child_field=None)`. Ia menggabungkan subpohon seluruh node menjadi satu himpunan id ter-deduplikasi lebih dulu, lalu menjumlahkannya sekali per record. Kembaliannya `dict` `{field_name: total}` dengan satu entri untuk setiap nama di `field_names`; `node_ids` kosong menghasilkan `0` untuk setiap field, bukan `dict` kosong.
* Method itu **memakai ulang seluruh helper `hierarchy_aggregate`** — `_check_hierarchy_aggregate_fields`, `_check_hierarchy_walk_fields`, `_hierarchy_subtree_ids`, `_hierarchy_aggregate_values`, dan konstanta `HIERARCHY_MAX_DEPTH` — jadi validasi field, penelusuran pohon, penghormatan ACL tanpa `sudo()`, dan batas rekursi 64 tingkat identik, tanpa duplikasi konstanta maupun format pesan `UserError` kedua.
* **`static/src/js/hierarchy_model.js`** — `_computeTotals()` tidak lagi menjumlahkan per-root di browser, melainkan memanggil method itu. Pemanggilan hanya terjadi saat **himpunan root berubah** (muat awal, domain berubah, pindah halaman pager, masuk/keluar mode pencarian) — bukan saat node dibuka, karena membuka node tidak mengubah root. Sisi browser tetap legacy (`odoo.define`, `AbstractModel.extend`).
* **`README.rst`** — kalimat batasan lama tentang subpohon yang tumpang-tindih dihapus, diganti pernyataan bahwa setiap record dihitung tepat sekali, plus catatan bahwa pada view `child_field`-saja grand total memang **tidak** sama dengan jumlah kolom yang terlihat (justru karena kolom yang terlihat itulah yang tumpang-tindih), bahwa grand total tidak berubah saat node dibuka/ditutup, dan dokumentasi kontrak method barunya.
* **`tests/`** — unit test Python murni (pemicu **P1**/**L-01**+**L-02**, dan **P2**/**L-04** untuk toleransi float).

## Cakupan uji

Positif:

* total atas satu id akar sama dengan `hierarchy_aggregate` untuk id itu;
* total atas `[kakek, anak, cucu]` sekaligus tetap sama dengan angka itu — pengunci regresi hitung-ganda;
* `node_ids` kosong menghasilkan `0` per field;
* hirarki yang sama ditelusuri lewat `parent_field` dan lewat `child_field` menghasilkan angka identik.

Negatif: field non-numerik, field numerik non-`store`, `parent_field` dan `child_field` sama-sama kosong, dan hirarki siklik (dibuat lewat SQL mentah karena `res.partner._check_parent_id` menolaknya lewat ORM) → seluruhnya memicu `UserError` berformat SSI.

Tidak ada skenario `odoo-yaml-test` baru: item ini tidak menambah atau mengubah aturan validasi arch, jadi tak ada perilaku deklaratif baru untuk diuji lewat YAML. Skenario YAML yang sudah ada tetap lulus apa adanya.

🤖 Generated with [Claude Code](https://claude.com/claude-code)