### PR TITLE
[UPD] ssi_web_hierarchy_view: sembunyikan aggregate monetary saat currency bercampur

### DIFF
--- a/ssi_web_hierarchy_view/README.rst
+++ b/ssi_web_hierarchy_view/README.rst
@@ -115,33 +115,74 @@ the very bottom of the tree::
 * Rounding and formatting follow the field itself: ``digits`` for a float, and
   for a ``monetary`` column the currency named by the ``currency_field`` that
   field declares — the view fetches that currency field next to the column
-  for that very reason. The grand total row reads its currency from the first
-  root on screen.
+  for that very reason.
+
+Monetary totals and mixed currencies
+------------------------------------
+
+A total of a ``monetary`` column is only ever shown as a number when **every
+record it is made of uses one and the same currency**. That set of currencies
+is reported by the **server**, which knows every descendant, rather than read
+off whichever row the browser happens to have loaded:
+
+* One currency — the amount is shown, formatted with that very currency, on a
+  parent row and on the grand total row alike.
+* Several currencies — **no amount is shown at all**. The cell shows an em
+  dash (``—``) and says why in its ``title`` tooltip. Adding up amounts of
+  different currencies is wrong arithmetic, and labelling the result with one
+  of them is wrong twice over, so the cell refuses rather than mislead.
+* Such a cell carries the class ``o_hierarchy_aggregate_mixed`` next to
+  ``o_hierarchy_aggregate``, so a database can restyle exactly those cells
+  without touching this module.
+* **Only a record whose value is neither zero nor empty contributes its
+  currency.** A row worth ``0`` in another currency says nothing about the
+  currency of the total, and letting it count would silence a column that is
+  in fact perfectly sound.
+* A total made of nothing but zeros reports no currency at all; it is then
+  formatted with the currency of the row itself, and with that of the first
+  root on screen for the grand total row.
 
 The totals are computed by ``hierarchy_aggregate(node_ids, field_names,
-parent_field=None, child_field=None)``, a method this module adds to every
-model. It returns ``{node_id: {field_name: total}}`` with one entry per given
-id, and is called **once per level** — for every id of that level at once,
-never once per node. Descendants are walked through ``parent_field`` when it
-is set and through ``child_field`` otherwise; ``child_of`` is deliberately
-not used, since it would require the walked field to be the model's
-``_parent_name``. Access rights are honoured — there is no ``sudo()``: a
-descendant the user may not read is left out of the total, consistently with
-the rows that user sees. A tree nested deeper than 64 levels is treated as
-cyclic data and raises, rather than looping forever.
+parent_field=None, child_field=None, with_currency=False)``, a method this
+module adds to every model. It returns ``{node_id: {field_name: total}}``
+with one entry per given id, and is called **once per level** — for every id
+of that level at once, never once per node. Descendants are walked through
+``parent_field`` when it is set and through ``child_field`` otherwise;
+``child_of`` is deliberately not used, since it would require the walked
+field to be the model's ``_parent_name``. Access rights are honoured — there
+is no ``sudo()``: a descendant the user may not read is left out of the
+total, consistently with the rows that user sees. A tree nested deeper than
+64 levels is treated as cyclic data and raises, rather than looping forever.
 
 The grand total row is computed by ``hierarchy_grand_total(node_ids,
-field_names, parent_field=None, child_field=None)``, a second method this
-module adds to every model. It merges the subtrees of ``node_ids`` into one
-single set of ids before summing, and returns ``{field_name: total}`` with
-one entry per given name — ``0`` for every name when ``node_ids`` is empty.
-That merge is what makes a record count exactly once even when several of
-its ancestors are on screen; it validates its fields, walks the tree and
-honours access rights exactly like ``hierarchy_aggregate``, so a grand total
-over one single root equals the total that method reports for that root. It
-is called only when the set of roots changes — first load, new domain, new
-page of the pager, entering or leaving search mode — never when a node is
-opened.
+field_names, parent_field=None, child_field=None, with_currency=False)``, a
+second method this module adds to every model. It merges the subtrees of
+``node_ids`` into one single set of ids before summing, and returns
+``{field_name: total}`` with one entry per given name — ``0`` for every name
+when ``node_ids`` is empty. That merge is what makes a record count exactly
+once even when several of its ancestors are on screen; it validates its
+fields, walks the tree and honours access rights exactly like
+``hierarchy_aggregate``, so a grand total over one single root equals the
+total that method reports for that root. It is called only when the set of
+roots changes — first load, new domain, new page of the pager, entering or
+leaving search mode — never when a node is opened.
+
+Both methods take the same optional ``with_currency`` keyword argument:
+
+* ``with_currency=False``, the default, returns exactly the shapes above —
+  ``{node_id: {field_name: total}}`` and ``{field_name: total}`` — so any
+  existing caller keeps working untouched.
+* ``with_currency=True`` turns every field entry into
+  ``{"total": total, "currency_ids": [id, ...]}``. ``currency_ids`` holds the
+  currencies of the records that actually contributed a non-zero value, and
+  is an **empty list** on a column that is not ``monetary``, so the browser
+  may send every aggregated column in one single call without sorting them
+  out first. A ``monetary`` field whose ``currency_field`` does not exist on
+  the model is **rejected** rather than silently ignored.
+
+The browser only asks for ``with_currency=True`` when at least one aggregated
+column is ``monetary``; on any other tree the calls and their answers are
+exactly what they were.
 
 Row decorations
 ---------------
@@ -312,6 +353,9 @@ Known limitations
 * Column aggregation is a **sum** only: ``avg=``, ``min=``, ``max=`` and a
   count of the descendants are not supported, and neither is exporting the
   totals to XLSX/CSV.
+* A mixed currency total is refused, not resolved: amounts are never
+  converted to the company currency, and one cell never shows one subtotal
+  per currency (see *Monetary totals and mixed currencies*).
 
 Installation
 ============

--- a/ssi_web_hierarchy_view/models/base.py
+++ b/ssi_web_hierarchy_view/models/base.py
@@ -19,6 +19,10 @@ HIERARCHY_AGGREGATABLE_TYPES = [
     "monetary",
 ]
 
+# The currency field a monetary field is read with when it declares none
+# of its own, the very fallback ``fields.Monetary`` itself applies.
+HIERARCHY_DEFAULT_CURRENCY_FIELD = "currency_id"
+
 
 class Base(models.AbstractModel):
     """
@@ -166,7 +170,12 @@ Solution: Break the parent loop in the data of model %s
         raise UserError(error_message)
 
     def hierarchy_aggregate(
-        self, node_ids, field_names, parent_field=None, child_field=None
+        self,
+        node_ids,
+        field_names,
+        parent_field=None,
+        child_field=None,
+        with_currency=False,
     ):
         """Return the subtree total of every field for every given node.
 
@@ -197,32 +206,43 @@ Solution: Break the parent loop in the data of model %s
         :param child_field: name of the ``one2many``/``many2many`` to
             this same model carrying the children of a record, used only
             when ``parent_field`` is not given
+        :param with_currency: whether every entry has to report the
+            currencies its total is made of besides the total itself
         :return: dict ``{node_id: {field_name: total}}`` holding one
-            entry for every id of ``node_ids``
+            entry for every id of ``node_ids``, every ``total`` becoming
+            ``{"total": total, "currency_ids": [id, ...]}`` when
+            ``with_currency`` is asked for
         :raises UserError: when a field of ``field_names`` does not
-            exist, is not numeric or is not stored, when neither
-            ``parent_field`` nor ``child_field`` is given, or when the
-            tree is nested deeper than ``HIERARCHY_MAX_DEPTH`` levels,
-            which only happens on cyclic data
+            exist, is not numeric or is not stored, when a monetary
+            field names a currency field that does not exist, when
+            neither ``parent_field`` nor ``child_field`` is given, or
+            when the tree is nested deeper than ``HIERARCHY_MAX_DEPTH``
+            levels, which only happens on cyclic data
         """
         self._check_hierarchy_aggregate_fields(field_names)
         self._check_hierarchy_walk_fields(parent_field, child_field)
+        currency_fields = self._hierarchy_currency_fields(field_names, with_currency)
         subtree_ids = self._hierarchy_subtree_ids(node_ids, parent_field, child_field)
-        values = self._hierarchy_aggregate_values(subtree_ids, field_names)
+        values = self._hierarchy_aggregate_values(
+            subtree_ids, field_names, currency_fields
+        )
         totals = {}
         for node_id, record_ids in subtree_ids.items():
-            totals[node_id] = {
-                field_name: sum(
-                    values[record_id].get(field_name) or 0
-                    for record_id in record_ids
-                    if record_id in values
-                )
-                for field_name in field_names
-            }
+            records = [
+                values[record_id] for record_id in record_ids if record_id in values
+            ]
+            totals[node_id] = self._hierarchy_totals(
+                records, field_names, currency_fields, with_currency
+            )
         return totals
 
     def hierarchy_grand_total(
-        self, node_ids, field_names, parent_field=None, child_field=None
+        self,
+        node_ids,
+        field_names,
+        parent_field=None,
+        child_field=None,
+        with_currency=False,
     ):
         """Return the total of every field over the union of the subtrees.
 
@@ -250,23 +270,156 @@ Solution: Break the parent loop in the data of model %s
         :param child_field: name of the ``one2many``/``many2many`` to
             this same model carrying the children of a record, used only
             when ``parent_field`` is not given
+        :param with_currency: whether every entry has to report the
+            currencies its total is made of besides the total itself
         :return: dict ``{field_name: total}`` holding one entry for every
             name of ``field_names``, the total being ``0`` when
-            ``node_ids`` is empty
+            ``node_ids`` is empty, every ``total`` becoming
+            ``{"total": total, "currency_ids": [id, ...]}`` when
+            ``with_currency`` is asked for
         :raises UserError: when a field of ``field_names`` does not
-            exist, is not numeric or is not stored, when neither
-            ``parent_field`` nor ``child_field`` is given, or when the
-            tree is nested deeper than ``HIERARCHY_MAX_DEPTH`` levels,
-            which only happens on cyclic data
+            exist, is not numeric or is not stored, when a monetary
+            field names a currency field that does not exist, when
+            neither ``parent_field`` nor ``child_field`` is given, or
+            when the tree is nested deeper than ``HIERARCHY_MAX_DEPTH``
+            levels, which only happens on cyclic data
         """
         self._check_hierarchy_aggregate_fields(field_names)
         self._check_hierarchy_walk_fields(parent_field, child_field)
+        currency_fields = self._hierarchy_currency_fields(field_names, with_currency)
         subtree_ids = self._hierarchy_subtree_ids(node_ids, parent_field, child_field)
-        values = self._hierarchy_aggregate_values(subtree_ids, field_names)
-        return {
-            field_name: sum(record.get(field_name) or 0 for record in values.values())
-            for field_name in field_names
-        }
+        values = self._hierarchy_aggregate_values(
+            subtree_ids, field_names, currency_fields
+        )
+        return self._hierarchy_totals(
+            list(values.values()), field_names, currency_fields, with_currency
+        )
+
+    def _hierarchy_currency_fields(self, field_names, with_currency):
+        """Resolve the currency field of every monetary field asked for.
+
+        Nothing at all is resolved when ``with_currency`` is not asked
+        for: the answer then carries no currency, so reading one would
+        only widen the query for nothing.
+
+        The currency is taken from the ``currency_field`` the monetary
+        field declares itself, which is exactly what the browser
+        formats a monetary value with, so the two can never disagree.
+
+        :param field_names: names of the fields being totalled, already
+            validated by :meth:`_check_hierarchy_aggregate_fields`
+        :param with_currency: whether the caller asked for the
+            currencies at all
+        :return: dict ``{field_name: currency field name}``, the name
+            being ``False`` on a field that is not monetary, the dict
+            being empty when ``with_currency`` is not asked for
+        :raises UserError: when a monetary field names a currency field
+            that does not exist on this model
+        """
+        currency_fields = {}
+        if not with_currency:
+            return currency_fields
+
+        for field_name in field_names:
+            field = self._fields[field_name]
+            if field.type != "monetary":
+                currency_fields[field_name] = False
+                continue
+            currency_field = (
+                getattr(field, "currency_field", False)
+                or HIERARCHY_DEFAULT_CURRENCY_FIELD
+            )
+            if currency_field not in self._fields:
+                self._raise_hierarchy_currency_field_error(field_name, currency_field)
+            currency_fields[field_name] = currency_field
+        return currency_fields
+
+    def _raise_hierarchy_currency_field_error(self, field_name, currency_field):
+        """Report a monetary column whose currency cannot be reached.
+
+        :param field_name: name of the monetary field being totalled
+        :param currency_field: name that field points its currency at
+        :raises UserError: always
+        """
+        error_message = _(
+            """
+Context: Aggregate a hierarchy view column
+Database ID: %s
+Problem: Field %s of model %s reads its currency from %s, which does not exist
+Solution: Point currency_field of field %s to a field of model %s
+"""
+            % (
+                self.id,
+                field_name,
+                self._name,
+                currency_field,
+                field_name,
+                self._name,
+            )
+        )
+        raise UserError(error_message)
+
+    def _hierarchy_totals(self, records, field_names, currency_fields, with_currency):
+        """Total every field over a set of records already read.
+
+        Shared by :meth:`hierarchy_aggregate`, which calls it once per
+        node, and by :meth:`hierarchy_grand_total`, which calls it once
+        over the whole union, so the two can never drift apart.
+
+        :param records: list of dicts as read by
+            :meth:`_hierarchy_aggregate_values`
+        :param field_names: names of the fields to total
+        :param currency_fields: dict as returned by
+            :meth:`_hierarchy_currency_fields`
+        :param with_currency: whether every entry has to report the
+            currencies its total is made of
+        :return: dict ``{field_name: total}``, every ``total`` becoming
+            ``{"total": total, "currency_ids": [id, ...]}`` when
+            ``with_currency`` is asked for
+        """
+        totals = {}
+        for field_name in field_names:
+            total = sum(record.get(field_name) or 0 for record in records)
+            if not with_currency:
+                totals[field_name] = total
+                continue
+            totals[field_name] = {
+                "total": total,
+                "currency_ids": self._hierarchy_currency_ids(
+                    records, field_name, currency_fields.get(field_name)
+                ),
+            }
+        return totals
+
+    def _hierarchy_currency_ids(self, records, field_name, currency_field):
+        """Collect the currencies a total is really made of.
+
+        Only a record carrying a value that is neither zero nor empty
+        contributes its currency: a row worth nothing in another
+        currency says nothing about the currency of the total, and
+        letting it count would silence a column that is in fact sound.
+
+        :param records: list of dicts as read by
+            :meth:`_hierarchy_aggregate_values`
+        :param field_name: name of the field being totalled
+        :param currency_field: name of the field carrying the currency,
+            ``False`` on a field that is not monetary
+        :return: sorted list of currency ids, empty on a field that is
+            not monetary and on a total made of nothing but zeros
+        """
+        if not currency_field:
+            return []
+
+        currency_ids = set()
+        for record in records:
+            if not record.get(field_name):
+                continue
+            value = record.get(currency_field)
+            if isinstance(value, (list, tuple)):
+                value = value[0] if value else False
+            if value:
+                currency_ids.add(value)
+        return sorted(currency_ids)
 
     def _check_hierarchy_aggregate_fields(self, field_names):
         """Reject a field that carries no summable stored value.
@@ -422,7 +575,7 @@ Solution: Add parent_field, child_field, or both to the hierarchy tag
                 children_ids[record["id"]] = list(record[child_field])
         return children_ids
 
-    def _hierarchy_aggregate_values(self, subtree_ids, field_names):
+    def _hierarchy_aggregate_values(self, subtree_ids, field_names, currency_fields):
         """Read the values every subtree total is built from.
 
         One single query for the union of every subtree: a record belongs
@@ -436,6 +589,10 @@ Solution: Add parent_field, child_field, or both to the hierarchy tag
         :param subtree_ids: dict ``{node_id: set of ids}`` as returned by
             :meth:`_hierarchy_subtree_ids`
         :param field_names: names of the numeric fields to read
+        :param currency_fields: dict as returned by
+            :meth:`_hierarchy_currency_fields`, whose values are read
+            next to the numeric fields so that the currencies of a total
+            cost no second query
         :return: dict ``{record_id: {field_name: value}}``, holding no
             entry for a record the current user may not read
         """
@@ -445,10 +602,13 @@ Solution: Add parent_field, child_field, or both to the hierarchy tag
         if not all_ids:
             return {}
 
+        read_names = list(field_names)
+        for currency_field in currency_fields.values():
+            if currency_field and currency_field not in read_names:
+                read_names.append(currency_field)
+
         values = {}
-        for record in self.search_read(
-            [("id", "in", sorted(all_ids))], list(field_names)
-        ):
+        for record in self.search_read([("id", "in", sorted(all_ids))], read_names):
             values[record["id"]] = record
         return values
 

--- a/ssi_web_hierarchy_view/static/src/js/hierarchy_model.js
+++ b/ssi_web_hierarchy_view/static/src/js/hierarchy_model.js
@@ -31,6 +31,36 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
         return value || false;
     }
 
+    /**
+     * @param {*} entry one field entry of a hierarchy_aggregate or
+     *      hierarchy_grand_total answer: a plain number when the
+     *      currencies were not asked for, a {total, currency_ids} pair
+     *      when they were
+     * @returns {Object} {total, currencyIds}, the one shape the renderer
+     *      reads whichever of the two the server answered
+     */
+    function toTotal(entry) {
+        if (entry && typeof entry === "object" && !Array.isArray(entry)) {
+            return {
+                total: entry.total || 0,
+                currencyIds: entry.currency_ids || [],
+            };
+        }
+        return {total: entry || 0, currencyIds: []};
+    }
+
+    /**
+     * @param {Object} entries the field entries of one answer
+     * @returns {Object} the same entries, every one of them normalized
+     */
+    function toTotals(entries) {
+        const totals = {};
+        for (const name of Object.keys(entries)) {
+            totals[name] = toTotal(entries[name]);
+        }
+        return totals;
+    }
+
     const HierarchyModel = AbstractModel.extend({
         /**
          * @override
@@ -47,7 +77,8 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
             // Grand totals of the aggregated columns over the union of
             // the subtrees of the roots on screen, keyed by field name,
             // every record counted exactly once. Computed server side.
-            // Empty when no column asks for a total at all.
+            // Each entry is a {total, currencyIds} pair. Empty when no
+            // column asks for a total at all.
             this.totals = {};
         },
 
@@ -79,6 +110,10 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
             this.childField = params.childField;
             this.parentField = params.parentField;
             this.aggregateFieldNames = params.aggregateFieldNames || [];
+            // Only a tree holding a monetary total needs the currencies:
+            // asking for them on an integer/float only tree would widen
+            // every answer for a list that is always empty.
+            this.aggregateWithCurrency = Boolean(params.aggregateWithCurrency);
             this.defaultExpand = params.defaultExpand;
             this.nodeLimit = params.limit;
             this.domain = params.domain || [];
@@ -413,9 +448,9 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
                 // match or one of the ancestors dragged along with it.
                 isMatch: false,
                 // Subtree totals of the aggregated columns, keyed by field
-                // name, own value of the row included. False until the
-                // server answered, and for good when no column asks for a
-                // total.
+                // name, own value of the row included, each entry being a
+                // {total, currencyIds} pair. False until the server
+                // answered, and for good when no column asks for a total.
                 aggregates: false,
             };
             return key;
@@ -483,6 +518,7 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
                 kwargs: {
                     parent_field: this.parentField || null,
                     child_field: this.childField || null,
+                    with_currency: this.aggregateWithCurrency,
                 },
                 context: this.context,
             }).then((totals) => {
@@ -491,7 +527,7 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
                     // JSON turns the integer keys of the answer into
                     // strings; indexing with the number reaches them all
                     // the same.
-                    row.aggregates = totals[row.id] || false;
+                    row.aggregates = totals[row.id] ? toTotals(totals[row.id]) : false;
                 }
             });
         },
@@ -524,7 +560,7 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
             const ids = this.rootKeys.map((key) => this.rows[key].id);
             if (!ids.length) {
                 for (const name of this.aggregateFieldNames) {
-                    this.totals[name] = 0;
+                    this.totals[name] = toTotal(0);
                 }
                 return Promise.resolve();
             }
@@ -535,10 +571,11 @@ odoo.define("ssi_web_hierarchy_view.HierarchyModel", function (require) {
                 kwargs: {
                     parent_field: this.parentField || null,
                     child_field: this.childField || null,
+                    with_currency: this.aggregateWithCurrency,
                 },
                 context: this.context,
             }).then((totals) => {
-                this.totals = totals;
+                this.totals = toTotals(totals);
             });
         },
 

--- a/ssi_web_hierarchy_view/static/src/js/hierarchy_renderer.js
+++ b/ssi_web_hierarchy_view/static/src/js/hierarchy_renderer.js
@@ -12,6 +12,7 @@ odoo.define("ssi_web_hierarchy_view.HierarchyRenderer", function (require) {
     const session = require("web.session");
 
     const qweb = core.qweb;
+    const _t = core._t;
 
     // Horizontal indentation added per hierarchy level, in pixels.
     const INDENT_PX = 20;
@@ -20,6 +21,17 @@ odoo.define("ssi_web_hierarchy_view.HierarchyRenderer", function (require) {
     // of the record itself, so that a total can be told apart from a value
     // and restyled by a database without touching this module.
     const AGGREGATE_CLASS = "o_hierarchy_aggregate";
+
+    // Class carried next to AGGREGATE_CLASS by a cell refusing to show a
+    // total, because the records it is made of do not share one single
+    // currency. Separate so that a database can restyle exactly those
+    // cells without touching this module.
+    const MIXED_CURRENCY_CLASS = "o_hierarchy_aggregate_mixed";
+
+    // Shown instead of such a total: adding up amounts of different
+    // currencies is wrong arithmetic under a label that is wrong too, so
+    // no number is shown at all rather than a misleading one.
+    const MIXED_CURRENCY_VALUE = "—";
 
     // The currency field a monetary field falls back to when it declares
     // none of its own, the same fallback field_utils applies.
@@ -363,7 +375,8 @@ odoo.define("ssi_web_hierarchy_view.HierarchyRenderer", function (require) {
          * Formats one cell of a row for display, using the same formatters
          * a list view uses. A column asking for a total shows the subtree
          * total on a row that has children and the row's own value on a
-         * leaf.
+         * leaf. A total made of several currencies at once is refused
+         * rather than formatted, since no currency could label it.
          *
          * @param {Object} row
          * @param {Object} column
@@ -374,7 +387,15 @@ odoo.define("ssi_web_hierarchy_view.HierarchyRenderer", function (require) {
             if (!field) {
                 return "";
             }
-            return this._formatValue(this.cellValue(row, column), field, row.data);
+            if (this.isMixedCurrencyCell(row, column)) {
+                return MIXED_CURRENCY_VALUE;
+            }
+            return this._formatValue(
+                this.cellValue(row, column),
+                field,
+                row.data,
+                this._cellCurrencyId(row, column)
+            );
         },
 
         /**
@@ -386,7 +407,7 @@ odoo.define("ssi_web_hierarchy_view.HierarchyRenderer", function (require) {
          */
         cellValue: function (row, column) {
             if (this.isAggregateCell(row, column)) {
-                return row.aggregates[column.name];
+                return row.aggregates[column.name].total;
             }
             return row.data[column.name];
         },
@@ -411,12 +432,91 @@ odoo.define("ssi_web_hierarchy_view.HierarchyRenderer", function (require) {
         },
 
         /**
+         * A total is only shown as a number when every record it is made
+         * of uses one and the same currency. The set of those currencies
+         * is reported by the server, which knows every descendant, and
+         * not guessed from the rows the browser happens to have loaded.
+         *
+         * @param {Object} row
+         * @param {Object} column
+         * @returns {Boolean} whether the cell has to refuse its total
+         */
+        isMixedCurrencyCell: function (row, column) {
+            if (!this.isAggregateCell(row, column)) {
+                return false;
+            }
+            return this._isMixedCurrency(row.aggregates[column.name]);
+        },
+
+        /**
+         * @private
+         * @param {Object} total a {total, currencyIds} entry
+         * @returns {Boolean} whether it is made of several currencies
+         */
+        _isMixedCurrency: function (total) {
+            return Boolean(total && (total.currencyIds || []).length > 1);
+        },
+
+        /**
+         * @private
+         * @param {Object} total a {total, currencyIds} entry
+         * @returns {Number|Boolean} the one currency the total is made
+         *      of, false when it is made of none or of several of them
+         */
+        _singleCurrencyId: function (total) {
+            const currencyIds = (total && total.currencyIds) || [];
+            return currencyIds.length === 1 ? currencyIds[0] : false;
+        },
+
+        /**
+         * @private
+         * @param {Object} row
+         * @param {Object} column
+         * @returns {Number|Boolean} the currency an aggregated cell is
+         *      formatted with, false when the cell shows a plain value
+         */
+        _cellCurrencyId: function (row, column) {
+            if (!this.isAggregateCell(row, column)) {
+                return false;
+            }
+            return this._singleCurrencyId(row.aggregates[column.name]);
+        },
+
+        /**
          * @param {Object} row
          * @param {Object} column
          * @returns {String} the extra classes of a body cell
          */
         cellClass: function (row, column) {
-            return this.isAggregateCell(row, column) ? AGGREGATE_CLASS : "";
+            if (!this.isAggregateCell(row, column)) {
+                return "";
+            }
+            if (this.isMixedCurrencyCell(row, column)) {
+                return AGGREGATE_CLASS + " " + MIXED_CURRENCY_CLASS;
+            }
+            return AGGREGATE_CLASS;
+        },
+
+        /**
+         * @param {Object} row
+         * @param {Object} column
+         * @returns {String|undefined} the tooltip of a body cell, left
+         *      out entirely unless the cell refuses its total: QWeb only
+         *      drops an attribute for ``undefined``/``null``
+         */
+        cellTitle: function (row, column) {
+            if (!this.isMixedCurrencyCell(row, column)) {
+                return undefined;
+            }
+            return this.mixedCurrencyTitle();
+        },
+
+        /**
+         * @returns {String} what a refused total says instead of showing
+         *      a number, spelled out for the reader of the tooltip
+         */
+        mixedCurrencyTitle: function () {
+            return _t("Mixed currencies: these records do not share one currency.");
         },
 
         /**
@@ -439,24 +539,50 @@ odoo.define("ssi_web_hierarchy_view.HierarchyRenderer", function (require) {
 
         /**
          * @param {Object} column
+         * @returns {Boolean} whether the grand total of that column is
+         *      made of several currencies and has to be refused
+         */
+        isMixedCurrencyTotal: function (column) {
+            if (!this.hasTotal(column)) {
+                return false;
+            }
+            return this._isMixedCurrency(this.state.totals[column.name]);
+        },
+
+        /**
+         * @param {Object} column
          * @returns {String} the extra classes of a grand total row cell
          */
         totalCellClass: function (column) {
-            return this.hasTotal(column) ? AGGREGATE_CLASS : "";
+            if (!this.hasTotal(column)) {
+                return "";
+            }
+            if (this.isMixedCurrencyTotal(column)) {
+                return AGGREGATE_CLASS + " " + MIXED_CURRENCY_CLASS;
+            }
+            return AGGREGATE_CLASS;
         },
 
         /**
          * The label given to ``sum=`` becomes the tooltip of the grand
-         * total, the same way a list view uses it. ``undefined`` rather
-         * than ``false`` on a column without a total: QWeb only leaves an
-         * attribute out for ``undefined``/``null``, and would otherwise
-         * render ``title="false"``.
+         * total, the same way a list view uses it; a refused total says
+         * instead why it shows no number, which is the only place that
+         * explanation can be read. ``undefined`` rather than ``false``
+         * on a column without a total: QWeb only leaves an attribute out
+         * for ``undefined``/``null``, and would otherwise render
+         * ``title="false"``.
          *
          * @param {Object} column
          * @returns {String|undefined}
          */
         totalTitle: function (column) {
-            return this.hasTotal(column) ? column.sum : undefined;
+            if (!this.hasTotal(column)) {
+                return undefined;
+            }
+            if (this.isMixedCurrencyTotal(column)) {
+                return this.mixedCurrencyTitle();
+            }
+            return column.sum;
         },
 
         /**
@@ -475,19 +601,25 @@ odoo.define("ssi_web_hierarchy_view.HierarchyRenderer", function (require) {
             if (!field) {
                 return "";
             }
+            if (this.isMixedCurrencyTotal(column)) {
+                return MIXED_CURRENCY_VALUE;
+            }
+            const total = this.state.totals[column.name];
             return this._formatValue(
-                this.state.totals[column.name],
+                total.total,
                 field,
-                this._totalRowData()
+                this._totalRowData(),
+                this._singleCurrencyId(total)
             );
         },
 
         /**
          * @private
          * @returns {Object|Boolean} the values a monetary grand total
-         *      reads its currency from: those of the first root on
-         *      screen, every root of one page sharing one currency in
-         *      practice
+         *      falls back to for its currency, used only when the server
+         *      reported no currency at all — a total made of nothing but
+         *      zeros — since a total made of exactly one currency is
+         *      formatted with that very one
          */
         _totalRowData: function () {
             const rootKey = this.state.rootKeys[0];
@@ -501,33 +633,49 @@ odoo.define("ssi_web_hierarchy_view.HierarchyRenderer", function (require) {
          * @param {Object} field the field description of the column
          * @param {Object|Boolean} data the values the row was read with,
          *      needed by a monetary column to resolve its currency
+         * @param {Number|Boolean} currencyId the currency an aggregated
+         *      value is made of, false when there is no total behind it
          * @returns {String}
          */
-        _formatValue: function (value, field, data) {
+        _formatValue: function (value, field, data, currencyId) {
             const formatter = field_utils.format[field.type];
             if (!formatter) {
                 return value === false || value === undefined ? "" : String(value);
             }
-            return formatter(value, field, this._formatOptions(field, data));
+            return formatter(
+                value,
+                field,
+                this._formatOptions(field, data, currencyId)
+            );
         },
 
         /**
-         * A monetary value is formatted with the currency held by the
-         * ``currency_field`` the field declares itself, which the view
-         * fetches next to the column for that very reason.
+         * A total is formatted with the one currency the server reported
+         * it to be made of; a plain value, and a total made of nothing
+         * but zeros, with the currency held by the ``currency_field``
+         * the field declares itself, which the view fetches next to the
+         * column for that very reason.
          *
          * @private
          * @param {Object} field the field description of the column
          * @param {Object|Boolean} data the values the row was read with
+         * @param {Number|Boolean} currencyId the currency reported for
+         *      an aggregated value, false when there is none
          * @returns {Object} the options handed to the formatter
          */
-        _formatOptions: function (field, data) {
-            if (field.type !== "monetary" || !data) {
+        _formatOptions: function (field, data, currencyId) {
+            if (field.type !== "monetary") {
+                return {};
+            }
+            if (currencyId) {
+                return {currency_id: currencyId};
+            }
+            if (!data) {
                 return {};
             }
             const currencyField = field.currency_field || DEFAULT_CURRENCY_FIELD;
-            const currencyId = toId(data[currencyField]);
-            return currencyId ? {currency_id: currencyId} : {};
+            const rowCurrencyId = toId(data[currencyField]);
+            return rowCurrencyId ? {currency_id: rowCurrencyId} : {};
         },
 
         /**

--- a/ssi_web_hierarchy_view/static/src/js/hierarchy_view.js
+++ b/ssi_web_hierarchy_view/static/src/js/hierarchy_view.js
@@ -97,6 +97,10 @@ odoo.define("ssi_web_hierarchy_view.HierarchyView", function (require) {
                 columns,
                 fields
             );
+            this.loadParams.aggregateWithCurrency = this._hasMonetaryAggregate(
+                columns,
+                fields
+            );
 
             this.withSearchPanel = false;
         },
@@ -156,6 +160,23 @@ odoo.define("ssi_web_hierarchy_view.HierarchyView", function (require) {
                 }
             }
             return _.uniq(names);
+        },
+
+        /**
+         * Whether the server has to report the currencies every total is
+         * made of. It only has to when at least one aggregated column is
+         * monetary: without any, no cell could ever be refused for
+         * mixing currencies, and asking would only widen the answer.
+         *
+         * @private
+         * @param {Array} columns
+         * @param {Object} fields viewInfo.fields
+         * @returns {Boolean}
+         */
+        _hasMonetaryAggregate: function (columns, fields) {
+            return this._aggregateFieldNames(columns, fields).some(
+                (name) => fields[name].type === "monetary"
+            );
         },
 
         /**

--- a/ssi_web_hierarchy_view/static/src/scss/hierarchy.scss
+++ b/ssi_web_hierarchy_view/static/src/scss/hierarchy.scss
@@ -108,6 +108,18 @@
     font-weight: bold;
 }
 
+// A total the records underneath do not agree on the currency of. No
+// number is shown at all there, only an em dash: summing amounts of
+// different currencies is wrong arithmetic under a label that is wrong
+// too. Muted and not bold, so the dash cannot read as a value, and
+// help-cursored, since the tooltip is where the reason is written. The
+// rule sits after .o_hierarchy_aggregate, whose weight it undoes.
+.o_hierarchy_aggregate_mixed {
+    font-weight: normal;
+    color: #6c757d;
+    cursor: help;
+}
+
 // The grand total of every root currently on screen, drawn once at the very
 // bottom of the tree. The rule sits after the decoration classes so that it
 // is never tinted by a decoration of the arch.

--- a/ssi_web_hierarchy_view/static/src/xml/hierarchy.xml
+++ b/ssi_web_hierarchy_view/static/src/xml/hierarchy.xml
@@ -60,6 +60,7 @@
                         <t t-foreach="columns.slice(1)" t-as="column">
                             <td
                                 t-attf-class="#{widget.cellClass(row, column)}"
+                                t-att-title="widget.cellTitle(row, column)"
                                 t-esc="widget.formatCell(row, column)"
                             />
                         </t>
@@ -72,7 +73,7 @@
                         <span class="o_hierarchy_total_label">Total</span>
                         <span
                             t-if="widget.hasTotal(columns[0])"
-                            class="o_hierarchy_label o_hierarchy_aggregate"
+                            t-attf-class="o_hierarchy_label #{widget.totalCellClass(columns[0])}"
                             t-att-title="widget.totalTitle(columns[0])"
                             t-esc="widget.formatTotal(columns[0])"
                         />

--- a/ssi_web_hierarchy_view/tests/test_ssi_web_hierarchy_view.py
+++ b/ssi_web_hierarchy_view/tests/test_ssi_web_hierarchy_view.py
@@ -2,10 +2,18 @@
 # Copyright 2026 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/AGPL).
 
+from unittest import mock
+
 from odoo_yaml_test import YamlTransactionCase
 
 from odoo.exceptions import UserError
 from odoo.tests import tagged
+
+# Name of the custom model the monetary scenarios are run on. No model of
+# ``base`` carries a ``monetary`` field at all, and this module depends on
+# ``base``/``web`` only, so amounts in several currencies can only be
+# totalled on a model declared by the test itself.
+CURRENCY_MODEL = "x_ssiwhv_amount"
 
 
 @tagged("post_install", "-at_install")
@@ -13,9 +21,9 @@ class TestSsiWebHierarchyView(YamlTransactionCase):
     """Covers the ``hierarchy`` view arch validation, search and totals.
 
     The arch validation scenarios live in the YAML file; the hierarchical
-    search, the subtree totals and the grand total are asserted here
-    because what is under test is the value
-    ``hierarchy_search_ancestors``, ``hierarchy_aggregate`` and
+    search, the subtree totals, the grand total and the currencies those
+    totals are made of are asserted here because what is under test is
+    the value ``hierarchy_search_ancestors``, ``hierarchy_aggregate`` and
     ``hierarchy_grand_total`` return.
     """
 
@@ -73,6 +81,120 @@ class TestSsiWebHierarchyView(YamlTransactionCase):
                 "parent_id": parent.id,
                 "color": 4,
                 "partner_latitude": 30.125,
+            }
+        )
+        return grandparent, parent, child
+
+    def _create_currency_model(self):
+        """Declare a custom model carrying a monetary hierarchy.
+
+        A model of its own is declared rather than custom fields added
+        to ``res.partner``: a brand new model carries no ``currency_id``
+        of any kind, so ``fields.Monetary`` can only resolve its
+        currency to the ``x_currency_id`` created here, whatever other
+        module happens to be installed next to this one.
+
+        The registry is restored afterwards, so the model never leaks
+        into another test.
+
+        Pure Python fixture — trigger P10 (L-09/L-10: the fixture has to
+        change the registry and register a cleanup restoring it, which
+        no YAML step can express).
+
+        :return: the name of the model that was created
+        """
+        self.addCleanup(self.env.registry.reset_changes)
+        model = self.env["ir.model"].create(
+            {
+                "name": "SSIWHV Amount Node",
+                "model": CURRENCY_MODEL,
+                "field_id": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "x_name",
+                            "ttype": "char",
+                            "field_description": "Name",
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "x_color",
+                            "ttype": "integer",
+                            "field_description": "Color",
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "x_currency_id",
+                            "ttype": "many2one",
+                            "relation": "res.currency",
+                            "field_description": "Currency",
+                        },
+                    ),
+                ],
+            }
+        )
+        field_model = self.env["ir.model.fields"]
+        # Both fields are added after the model itself: the parent points
+        # at the model, and the monetary field can only pick up
+        # x_currency_id once that field is part of the model.
+        field_model.create(
+            {
+                "name": "x_parent_id",
+                "model_id": model.id,
+                "ttype": "many2one",
+                "relation": CURRENCY_MODEL,
+                "field_description": "Parent",
+            }
+        )
+        field_model.create(
+            {
+                "name": "x_amount",
+                "model_id": model.id,
+                "ttype": "monetary",
+                "field_description": "Amount",
+            }
+        )
+        return CURRENCY_MODEL
+
+    def _create_amount_chain(self, currencies, amounts):
+        """Create a three level chain of monetary nodes.
+
+        :param currencies: the three currencies, the deepest node last
+        :param amounts: the three amounts, the deepest node last
+        :return: tuple of the grandparent, the parent and the child
+        """
+        node_model = self.env[CURRENCY_MODEL]
+        grandparent = node_model.create(
+            {
+                "x_name": "SSIWHV Amount Grandparent",
+                "x_color": 1,
+                "x_currency_id": currencies[0].id,
+                "x_amount": amounts[0],
+            }
+        )
+        parent = node_model.create(
+            {
+                "x_name": "SSIWHV Amount Parent",
+                "x_parent_id": grandparent.id,
+                "x_color": 2,
+                "x_currency_id": currencies[1].id,
+                "x_amount": amounts[1],
+            }
+        )
+        child = node_model.create(
+            {
+                "x_name": "SSIWHV Amount Child",
+                "x_parent_id": parent.id,
+                "x_color": 4,
+                "x_currency_id": currencies[2].id,
+                "x_amount": amounts[2],
             }
         )
         return grandparent, parent, child
@@ -613,3 +735,230 @@ class TestSsiWebHierarchyView(YamlTransactionCase):
                 [root.id], ["color"], parent_field="parent_id"
             )
         self.assertIn("nested deeper than 64 levels", str(error.exception))
+
+    def test_aggregate_without_currency_keeps_the_old_shape(self):
+        """Assert the default answer is the plain number it always was.
+
+        This is the regression lock of the contract documented in
+        ``README.rst``: a caller that never heard of ``with_currency``
+        has to keep reading ``{node_id: {field_name: <number>}}`` and
+        ``{field_name: <number>}``, not a nested dict.
+
+        Pure Python — trigger P1 (L-01: the ``call`` action discards the
+        return value of a method, and L-02 only lets an assert reach a
+        field of a record, never a returned dict) and trigger P2 (L-04:
+        there is no float tolerance in YAML).
+        """
+        self._create_currency_model()
+        usd = self.env.ref("base.USD")
+        eur = self.env.ref("base.EUR")
+        grandparent = self._create_amount_chain([usd, eur, usd], [100.0, 20.0, 5.0])[0]
+        node_model = self.env[CURRENCY_MODEL]
+        totals = node_model.hierarchy_aggregate(
+            [grandparent.id], ["x_amount"], parent_field="x_parent_id"
+        )
+        self.assertNotIsInstance(totals[grandparent.id]["x_amount"], dict)
+        self.assertAlmostEqual(totals[grandparent.id]["x_amount"], 125.0, places=2)
+
+        grand_totals = node_model.hierarchy_grand_total(
+            [grandparent.id], ["x_amount"], parent_field="x_parent_id"
+        )
+        self.assertNotIsInstance(grand_totals["x_amount"], dict)
+        self.assertAlmostEqual(grand_totals["x_amount"], 125.0, places=2)
+
+    def test_aggregate_with_currency_reports_one_currency(self):
+        """Assert a subtree of one single currency reports exactly one id.
+
+        Pure Python — trigger P1 (L-01: the ``call`` action discards the
+        return value of a method, and L-02 only lets an assert reach a
+        field of a record, never a returned dict) and trigger P2 (L-04:
+        there is no float tolerance in YAML).
+        """
+        self._create_currency_model()
+        usd = self.env.ref("base.USD")
+        grandparent = self._create_amount_chain([usd, usd, usd], [100.0, 20.0, 5.0])[0]
+        totals = self.env[CURRENCY_MODEL].hierarchy_aggregate(
+            [grandparent.id],
+            ["x_amount"],
+            parent_field="x_parent_id",
+            with_currency=True,
+        )
+        entry = totals[grandparent.id]["x_amount"]
+        self.assertEqual(entry["currency_ids"], [usd.id])
+        self.assertAlmostEqual(entry["total"], 125.0, places=2)
+
+    def test_aggregate_with_currency_reports_mixed_currencies(self):
+        """Assert a subtree of two currencies reports both of their ids.
+
+        The total itself stays the raw arithmetic sum: nothing is
+        converted here, the browser is only told not to show it.
+
+        Pure Python — trigger P1 (L-01: the ``call`` action discards the
+        return value of a method, and L-02 only lets an assert reach a
+        field of a record, never a returned dict) and trigger P2 (L-04:
+        there is no float tolerance in YAML).
+        """
+        self._create_currency_model()
+        usd = self.env.ref("base.USD")
+        eur = self.env.ref("base.EUR")
+        chain = self._create_amount_chain([usd, eur, usd], [100.0, 20.0, 5.0])
+        grandparent = chain[0]
+        child = chain[2]
+        totals = self.env[CURRENCY_MODEL].hierarchy_aggregate(
+            [grandparent.id, child.id],
+            ["x_amount"],
+            parent_field="x_parent_id",
+            with_currency=True,
+        )
+        mixed = totals[grandparent.id]["x_amount"]
+        self.assertEqual(set(mixed["currency_ids"]), {usd.id, eur.id})
+        self.assertAlmostEqual(mixed["total"], 125.0, places=2)
+        # The leaf underneath the mixed parent stays perfectly readable.
+        leaf = totals[child.id]["x_amount"]
+        self.assertEqual(leaf["currency_ids"], [usd.id])
+        self.assertAlmostEqual(leaf["total"], 5.0, places=2)
+
+    def test_aggregate_with_currency_ignores_a_zero_amount(self):
+        """Assert a zero in another currency does not silence a column.
+
+        A row worth nothing says nothing about the currency of the
+        total, so it must not turn a sound column into a refused one.
+
+        Pure Python — trigger P1 (L-01: the ``call`` action discards the
+        return value of a method, and L-02 only lets an assert reach a
+        field of a record, never a returned dict) and trigger P2 (L-04:
+        there is no float tolerance in YAML).
+        """
+        self._create_currency_model()
+        usd = self.env.ref("base.USD")
+        eur = self.env.ref("base.EUR")
+        grandparent = self._create_amount_chain([usd, eur, usd], [100.0, 0.0, 5.0])[0]
+        totals = self.env[CURRENCY_MODEL].hierarchy_aggregate(
+            [grandparent.id],
+            ["x_amount"],
+            parent_field="x_parent_id",
+            with_currency=True,
+        )
+        entry = totals[grandparent.id]["x_amount"]
+        self.assertEqual(entry["currency_ids"], [usd.id])
+        self.assertAlmostEqual(entry["total"], 105.0, places=2)
+
+    def test_aggregate_with_currency_reports_none_for_a_plain_field(self):
+        """Assert a field that is not monetary reports an empty list.
+
+        The browser sends every aggregated column in one single call, so
+        a plain integer column has to answer without raising anything.
+
+        Pure Python — trigger P1 (L-01: the ``call`` action discards the
+        return value of a method, and L-02 only lets an assert reach a
+        field of a record, never a returned dict).
+        """
+        self._create_currency_model()
+        usd = self.env.ref("base.USD")
+        eur = self.env.ref("base.EUR")
+        grandparent = self._create_amount_chain([usd, eur, usd], [100.0, 20.0, 5.0])[0]
+        totals = self.env[CURRENCY_MODEL].hierarchy_aggregate(
+            [grandparent.id],
+            ["x_color", "x_amount"],
+            parent_field="x_parent_id",
+            with_currency=True,
+        )
+        self.assertEqual(totals[grandparent.id]["x_color"]["currency_ids"], [])
+        self.assertEqual(totals[grandparent.id]["x_color"]["total"], 7)
+
+    def test_grand_total_with_currency_deduplicates_currencies(self):
+        """Assert the grand total reports the union of the currencies.
+
+        Handing over a grandparent, its child and its grandchild at once
+        is what a ``child_field``-only view does; the currencies of the
+        overlapping subtrees have to come back deduplicated, exactly
+        like the amount itself.
+
+        Pure Python — trigger P1 (L-01: the ``call`` action discards the
+        return value of a method, and L-02 only lets an assert reach a
+        field of a record, never a returned dict) and trigger P2 (L-04:
+        there is no float tolerance in YAML).
+        """
+        self._create_currency_model()
+        usd = self.env.ref("base.USD")
+        eur = self.env.ref("base.EUR")
+        grandparent, parent, child = self._create_amount_chain(
+            [usd, eur, usd], [100.0, 20.0, 5.0]
+        )
+        totals = self.env[CURRENCY_MODEL].hierarchy_grand_total(
+            [grandparent.id, parent.id, child.id],
+            ["x_amount"],
+            parent_field="x_parent_id",
+            with_currency=True,
+        )
+        entry = totals["x_amount"]
+        self.assertEqual(len(entry["currency_ids"]), 2)
+        self.assertEqual(set(entry["currency_ids"]), {usd.id, eur.id})
+        self.assertAlmostEqual(entry["total"], 125.0, places=2)
+
+    def test_grand_total_with_currency_reports_one_currency(self):
+        """Assert a grand total of one single currency reports one id.
+
+        Pure Python — trigger P1 (L-01: the ``call`` action discards the
+        return value of a method, and L-02 only lets an assert reach a
+        field of a record, never a returned dict) and trigger P2 (L-04:
+        there is no float tolerance in YAML).
+        """
+        self._create_currency_model()
+        usd = self.env.ref("base.USD")
+        grandparent = self._create_amount_chain([usd, usd, usd], [100.0, 20.0, 5.0])[0]
+        totals = self.env[CURRENCY_MODEL].hierarchy_grand_total(
+            [grandparent.id],
+            ["x_amount"],
+            parent_field="x_parent_id",
+            with_currency=True,
+        )
+        self.assertEqual(totals["x_amount"]["currency_ids"], [usd.id])
+        self.assertAlmostEqual(totals["x_amount"]["total"], 125.0, places=2)
+
+    def test_aggregate_rejects_an_unreachable_currency_field(self):
+        """Reject a monetary field whose currency field does not exist.
+
+        Silently dropping it would hand the browser a column it believes
+        to be single-currency while nothing was ever read to prove it.
+
+        Pure Python — trigger P1 (L-01: the method is called for its
+        return value, and L-02 keeps YAML asserts on record fields) and
+        trigger P6 (L-15: the field has to be patched, since a monetary
+        field pointing nowhere cannot even be set up by the registry).
+        """
+        self._create_currency_model()
+        node_model = self.env[CURRENCY_MODEL]
+        field = node_model._fields["x_amount"]
+        with mock.patch.object(field, "currency_field", "x_no_such_currency"):
+            with self.assertRaises(UserError) as error:
+                node_model.hierarchy_aggregate(
+                    [],
+                    ["x_amount"],
+                    parent_field="x_parent_id",
+                    with_currency=True,
+                )
+        self.assertIn("x_no_such_currency", str(error.exception))
+        self.assertIn("does not exist", str(error.exception))
+
+    def test_grand_total_rejects_an_unreachable_currency_field(self):
+        """Reject the same unreachable currency field on the grand total.
+
+        Pure Python — trigger P1 (L-01: the method is called for its
+        return value, and L-02 keeps YAML asserts on record fields) and
+        trigger P6 (L-15: the field has to be patched, since a monetary
+        field pointing nowhere cannot even be set up by the registry).
+        """
+        self._create_currency_model()
+        node_model = self.env[CURRENCY_MODEL]
+        field = node_model._fields["x_amount"]
+        with mock.patch.object(field, "currency_field", "x_no_such_currency"):
+            with self.assertRaises(UserError) as error:
+                node_model.hierarchy_grand_total(
+                    [],
+                    ["x_amount"],
+                    parent_field="x_parent_id",
+                    with_currency=True,
+                )
+        self.assertIn("x_no_such_currency", str(error.exception))
+        self.assertIn("does not exist", str(error.exception))


### PR DESCRIPTION
Closes #92

## Ringkasan

Sebuah agregat `monetary` — pada baris induk maupun baris grand total — kini hanya
ditampilkan sebagai angka bila **seluruh** record yang menyumbangnya memakai currency
yang sama. Bila bercampur, sel menolak menampilkan angka dan mengatakan alasannya.

## Server (`models/base.py`)

* `hierarchy_aggregate` dan `hierarchy_grand_total` menerima argumen kata kunci
  `with_currency=False`.
  * `False` (default) → bentuk kembalian **persis seperti sebelumnya**
    (`{node_id: {field_name: total}}` dan `{field_name: total}`). Kontrak yang sudah
    didokumentasikan di `README.rst` tidak berubah.
  * `True` → tiap entri field menjadi `{"total": <angka>, "currency_ids": [<id>, …]}`.
* Currency diambil dari `currency_field` yang dideklarasikan field monetary itu sendiri,
  dengan fallback ke `currency_id` — konsisten dengan cara `_formatOptions` bekerja.
* **Hanya record dengan nilai bukan nol yang menyumbangkan currency-nya**, supaya satu
  baris nol berbeda currency tidak membungkam kolom yang sebenarnya sehat.
* Field non-monetary melaporkan `currency_ids` list kosong, bukan error, sehingga browser
  boleh mengirim seluruh kolom teragregasi dalam satu panggilan.
* Field monetary yang `currency_field`-nya tidak ada pada model ditolak dengan `UserError`
  berformat SSI (`Context`/`Database ID`/`Problem`/`Solution`).

## Browser (`static/src/`)

* `hierarchy_view.js` mengirim `with_currency=True` hanya bila ada minimal satu kolom
  teragregasi bertipe `monetary`.
* `hierarchy_model.js` menormalkan kedua bentuk jawaban server menjadi satu bentuk
  `{total, currencyIds}` yang dibaca renderer.
* `hierarchy_renderer.js`: `currency_ids` berisi 0 atau 1 id → angka ditampilkan dan
  diformat dengan currency itu; lebih dari 1 id → em dash (`—`) beserta atribut `title`
  yang menerangkan currency-nya bercampur. Berlaku pada baris induk **dan** baris grand
  total.
* Sel yang ditolak memakai kelas `o_hierarchy_aggregate_mixed`, berdampingan dengan
  `o_hierarchy_aggregate` yang sudah ada, dan digayai lewat SCSS.
* Sisi browser tetap legacy (`odoo.define`, `AbstractRenderer.extend`) — 14.0, bukan OWL.

## Dokumentasi

`README.rst`: batasan lama ("grand total membaca currency dari root pertama") dihapus,
diganti bagian *Monetary totals and mixed currencies* plus kontrak `with_currency`.

## Unit test

Ditambahkan skenario Python murni (pemicu **P1**/**P2**, fixture **P10**, mock **P6**):
subtree satu currency, subtree dua currency, descendant bernilai nol di currency lain,
field non-monetary, dedup currency pada grand total, pengunci regresi bentuk lama
`with_currency=False`, dan penolakan `currency_field` yang tidak ada. Tidak ada skenario
`odoo-yaml-test` baru — item ini tidak menambah aturan validasi arch; skenario YAML yang
sudah ada tetap dijalankan apa adanya.