### PR TITLE
[UPD] ssi_web_login

### DIFF
--- a/ssi_web_login/README.rst
+++ b/ssi_web_login/README.rst
@@ -6,6 +6,11 @@
 SSI Web Login
 =============
 
+Replaces the "Email"/"Your Email" label with "Username" across every web
+authentication surface (login, signup, reset password) and overrides the
+``auth_signup`` invitation and set-password mail templates so invited users
+are told their ``res.users.login`` value instead of their email address.
+
 
 Installation
 ============

--- a/ssi_web_login/__manifest__.py
+++ b/ssi_web_login/__manifest__.py
@@ -11,9 +11,12 @@
     "application": False,
     "depends": [
         "web",
+        "auth_signup",
     ],
     "data": [
+        "data/auth_signup_mail_template_data.xml",
         "views/webclient_templates.xml",
+        "views/auth_signup_templates.xml",
     ],
     "demo": [],
 }

--- a/ssi_web_login/data/auth_signup_mail_template_data.xml
+++ b/ssi_web_login/data/auth_signup_mail_template_data.xml
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). -->
+<odoo>
+    <record id="auth_signup.set_password_email" model="mail.template">
+        <field name="body_html" type="html">
+<table
+                border="0"
+                cellpadding="0"
+                cellspacing="0"
+                style="padding-top: 16px; background-color: #F1F1F1; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;"
+            ><tr><td align="center">
+<table
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            width="590"
+                            style="padding: 16px; background-color: white; color: #454748; border-collapse:separate;"
+                        >
+<tbody>
+    <!-- HEADER -->
+    <tr>
+        <td align="center" style="min-width: 590px;">
+            <table
+                                            border="0"
+                                            cellpadding="0"
+                                            cellspacing="0"
+                                            width="590"
+                                            style="min-width: 590px; background-color: white; padding: 0px 8px 0px 8px; border-collapse:separate;"
+                                        >
+                <tr><td valign="middle">
+                    <span style="font-size: 10px;">Welcome to Odoo</span><br />
+                    <span style="font-size: 20px; font-weight: bold;">
+                        ${object.name}
+                    </span>
+                </td><td valign="middle" align="right">
+                    <img
+                                                        src="/logo.png?company=${object.company_id.id}"
+                                                        style="padding: 0px; margin: 0px; height: auto; width: 80px;"
+                                                        alt="${object.company_id.name}"
+                                                    />
+                </td></tr>
+                <tr><td colspan="2" style="text-align:center;">
+                  <hr
+                                                        width="100%"
+                                                        style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 16px 0px 16px 0px;"
+                                                    />
+                </td></tr>
+            </table>
+        </td>
+    </tr>
+    <!-- CONTENT -->
+    <tr>
+        <td align="center" style="min-width: 590px;">
+            <table
+                                            border="0"
+                                            cellpadding="0"
+                                            cellspacing="0"
+                                            width="590"
+                                            style="min-width: 590px; background-color: white; padding: 0px 8px 0px 8px; border-collapse:separate;"
+                                        >
+                <tr><td valign="top" style="font-size: 13px;">
+                    <div>
+                        Dear ${object.name},<br /><br />
+                        You have been invited by ${object.create_uid.name} of ${object.company_id.name} to connect on Odoo.
+                        <div style="margin: 16px 0px 16px 0px;">
+                            <a
+                                                                href="${object.signup_url}"
+                                                                style="background-color: #875A7B; padding: 8px 16px 8px 16px; text-decoration: none; color: #fff; border-radius: 5px; font-size:13px;"
+                                                            >
+                                Accept invitation
+                            </a>
+                        </div>
+                        % set website_url = object.env['ir.config_parameter'].sudo().get_param('web.base.url')
+                        Your Odoo domain is: <b><a
+                                                                href='${website_url}'
+                                                            >${website_url}</a></b><br
+                                                        />
+                        Your login is: <b><a
+                                                                href="/web/login?login=${object.login}"
+                                                                target="_blank"
+                                                            >${object.login}</a></b><br
+                                                        /><br />
+                        Never heard of Odoo? It’s an all-in-one business software loved by 3+ million users. It will considerably improve your experience at work and increase your productivity.
+                        <br /><br />
+                        Have a look at the <a
+                                                            href="https://www.odoo.com/page/tour?utm_source=db&amp;utm_medium=auth"
+                                                            style="color: #875A7B;"
+                                                        >Odoo Tour</a> to discover the tool.
+                        <br /><br />
+                        Enjoy Odoo!<br />
+                        --<br />The ${object.company_id.name} Team
+                    </div>
+                </td></tr>
+                <tr><td style="text-align:center;">
+                  <hr
+                                                        width="100%"
+                                                        style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 16px 0px 16px 0px;"
+                                                    />
+                </td></tr>
+            </table>
+        </td>
+    </tr>
+    <!-- FOOTER -->
+    <tr>
+        <td align="center" style="min-width: 590px;">
+            <table
+                                            border="0"
+                                            cellpadding="0"
+                                            cellspacing="0"
+                                            width="590"
+                                            style="min-width: 590px; background-color: white; font-size: 11px; padding: 0px 8px 0px 8px; border-collapse:separate;"
+                                        >
+                <tr><td valign="middle" align="left">
+                    ${object.company_id.name}
+                </td></tr>
+                <tr><td valign="middle" align="left" style="opacity: 0.7;">
+                    ${object.company_id.phone}
+                    % if object.company_id.email
+                        | <a
+                                                        href="'mailto:%s' % ${object.company_id.email}"
+                                                        style="text-decoration:none; color: #454748;"
+                                                    >${object.company_id.email}</a>
+                    % endif
+                    % if object.company_id.website
+                        | <a
+                                                        href="'%s' % ${object.company_id.website}"
+                                                        style="text-decoration:none; color: #454748;"
+                                                    >
+                        ${object.company_id.website}
+                    </a>
+                    % endif
+                </td></tr>
+            </table>
+        </td>
+    </tr>
+</tbody>
+</table>
+</td></tr>
+<!-- POWERED BY -->
+<tr><td align="center" style="min-width: 590px;">
+    <table
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            width="590"
+                            style="min-width: 590px; background-color: #F1F1F1; color: #454748; padding: 8px; border-collapse:separate;"
+                        >
+      <tr><td style="text-align: center; font-size: 13px;">
+        Powered by <a
+                                        target="_blank"
+                                        href="https://www.odoo.com?utm_source=db&amp;utm_medium=auth"
+                                        style="color: #875A7B;"
+                                    >Odoo</a>
+      </td></tr>
+    </table>
+</td></tr>
+</table>
+        </field>
+    </record>
+
+    <record
+        id="auth_signup.mail_template_user_signup_account_created"
+        model="mail.template"
+    >
+        <field name="body_html" type="html">
+<table
+                border="0"
+                cellpadding="0"
+                cellspacing="0"
+                style="padding-top: 16px; background-color: #F1F1F1; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;"
+            ><tr><td align="center">
+<table
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            width="590"
+                            style="padding: 16px; background-color: white; color: #454748; border-collapse:separate;"
+                        >
+<tbody>
+    <!-- HEADER -->
+    <tr>
+        <td align="center" style="min-width: 590px;">
+            <table
+                                            border="0"
+                                            cellpadding="0"
+                                            cellspacing="0"
+                                            width="590"
+                                            style="min-width: 590px; background-color: white; padding: 0px 8px 0px 8px; border-collapse:separate;"
+                                        >
+                <tr><td valign="middle">
+                    <span style="font-size: 10px;">Your Account</span><br />
+                    <span style="font-size: 20px; font-weight: bold;">
+                        ${object.name}
+                    </span>
+                </td><td valign="middle" align="right">
+                    <img
+                                                        src="/logo.png?company=${object.company_id.id}"
+                                                        style="padding: 0px; margin: 0px; height: auto; width: 80px;"
+                                                        alt="${object.company_id.name}"
+                                                    />
+                </td></tr>
+                <tr><td colspan="2" style="text-align:center;">
+                  <hr
+                                                        width="100%"
+                                                        style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 16px 0px 16px 0px;"
+                                                    />
+                </td></tr>
+            </table>
+        </td>
+    </tr>
+    <!-- CONTENT -->
+    <tr>
+        <td align="center" style="min-width: 590px;">
+            <table
+                                            border="0"
+                                            cellpadding="0"
+                                            cellspacing="0"
+                                            width="590"
+                                            style="min-width: 590px; background-color: white; padding: 0px 8px 0px 8px; border-collapse:separate;"
+                                        >
+                <tr><td valign="top" style="font-size: 13px;">
+                    <div>
+                        Dear ${object.name},<br /><br />
+                        Your account has been successfully created!<br />
+                        Your login is <strong>${object.login}</strong><br />
+                        To gain access to your account, you can use the following link:
+                        <div style="margin: 16px 0px 16px 0px;">
+                            <a
+                                                                href="/web/login?auth_login=${object.login}"
+                                                                style="background-color: #875A7B; padding: 8px 16px 8px 16px; text-decoration: none; color: #fff; border-radius: 5px; font-size:13px;"
+                                                            >
+                                Go to My Account
+                            </a>
+                        </div>
+                        Thanks,<br />
+                        % if user.signature:
+                            <br />
+                            ${user.signature | safe}
+                        % endif
+                    </div>
+                </td></tr>
+                <tr><td style="text-align:center;">
+                  <hr
+                                                        width="100%"
+                                                        style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 16px 0px 16px 0px;"
+                                                    />
+                </td></tr>
+            </table>
+        </td>
+    </tr>
+    <!-- FOOTER -->
+    <tr>
+        <td align="center" style="min-width: 590px;">
+            <table
+                                            border="0"
+                                            cellpadding="0"
+                                            cellspacing="0"
+                                            width="590"
+                                            style="min-width: 590px; background-color: white; font-size: 11px; padding: 0px 8px 0px 8px; border-collapse:separate;"
+                                        >
+                <tr><td valign="middle" align="left">
+                    ${object.company_id.name}
+                </td></tr>
+                <tr><td valign="middle" align="left" style="opacity: 0.7;">
+                    ${object.company_id.phone}
+                    % if object.company_id.email
+                        | <a
+                                                        href="'mailto:%s' % ${object.company_id.email}"
+                                                        style="text-decoration:none; color: #454748;"
+                                                    >${object.company_id.email}</a>
+                    % endif
+                    % if object.company_id.website
+                        | <a
+                                                        href="'%s' % ${object.company_id.website}"
+                                                        style="text-decoration:none; color: #454748;"
+                                                    >
+                        ${object.company_id.website}
+                    </a>
+                    % endif
+                </td></tr>
+            </table>
+        </td>
+    </tr>
+</tbody>
+</table>
+</td></tr>
+<!-- POWERED BY -->
+<tr><td align="center" style="min-width: 590px;">
+    <table
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            width="590"
+                            style="min-width: 590px; background-color: #F1F1F1; color: #454748; padding: 8px; border-collapse:separate;"
+                        >
+      <tr><td style="text-align: center; font-size: 13px;">
+        Powered by <a
+                                        target="_blank"
+                                        href="https://www.odoo.com?utm_source=db&amp;utm_medium=auth"
+                                        style="color: #875A7B;"
+                                    >Odoo</a>
+      </td></tr>
+    </table>
+</td></tr>
+</table>
+        </field>
+    </record>
+</odoo>

--- a/ssi_web_login/tests/__init__.py
+++ b/ssi_web_login/tests/__init__.py
@@ -3,3 +3,4 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from . import test_ssi_web_login
+from . import test_auth_signup_login_http

--- a/ssi_web_login/tests/test_auth_signup_login_http.py
+++ b/ssi_web_login/tests/test_auth_signup_login_http.py
@@ -1,0 +1,45 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo.tests import HttpCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestAuthSignupLoginHttp(HttpCase):
+    """Render the login and reset password pages over HTTP."""
+
+    def setUp(self):
+        """Activate the ``auth_signup.reset_password`` system parameter."""
+        super().setUp()
+        self.env["ir.config_parameter"].sudo().set_param(
+            "auth_signup.reset_password", "True"
+        )
+
+    def test_login_page_shows_username_label(self):
+        """Assert the login page uses "Username", not "Your Email".
+
+        Pure Python -- trigger P7 (L-19: ``HttpCase``, a rendered HTTP
+        response body, is unreachable from the YAML DSL, whose base
+        class is locked to ``TransactionCase``). Also asserts the
+        existing ``ssi_web_login.login`` view still renders the
+        password field and the submit button.
+        """
+        response = self.url_open("/web/login")
+        body = response.content.decode()
+        self.assertIn("Username", body)
+        self.assertNotIn("Your Email", body)
+        self.assertIn('id="password"', body)
+        self.assertIn('type="submit"', body)
+
+    def test_reset_password_page_shows_username_label(self):
+        """Assert the reset password page uses "Your Username".
+
+        Pure Python -- trigger P7 (L-19: ``HttpCase``, a rendered HTTP
+        response body, is unreachable from the YAML DSL, whose base
+        class is locked to ``TransactionCase``).
+        """
+        response = self.url_open("/web/reset_password")
+        body = response.content.decode()
+        self.assertIn("Your Username", body)
+        self.assertNotIn("Your Email", body)

--- a/ssi_web_login/tests/test_data_ssi_web_login.yaml
+++ b/ssi_web_login/tests/test_data_ssi_web_login.yaml
@@ -9,3 +9,75 @@ scenarios:
           - ["state", "=", "installed"]
         save_as: "module"
         expect_count: 1
+
+  - name: "ssi_web_login - Auth signup fields template overrides login label"
+    steps:
+      - step: "Get auth_signup.fields override view"
+        action: "ref"
+        xml_id: "ssi_web_login.auth_signup_fields"
+        save_as: "view"
+      - step: "Assert view is active and inherits auth_signup.fields"
+        action: "assert"
+        target: "view"
+        asserts:
+          active:
+            type: "value"
+            operator: "is_truthy"
+          inherit_id:
+            type: "m2o"
+            expected_xml_id: "auth_signup.fields"
+          arch_db:
+            type: "value"
+            operator: "contains"
+            expected: "Your Username"
+
+  - name: "ssi_web_login - Auth signup reset password template overrides login label"
+    steps:
+      - step: "Get auth_signup.reset_password override view"
+        action: "ref"
+        xml_id: "ssi_web_login.auth_signup_reset_password"
+        save_as: "view"
+      - step: "Assert view is active and inherits auth_signup.reset_password"
+        action: "assert"
+        target: "view"
+        asserts:
+          active:
+            type: "value"
+            operator: "is_truthy"
+          inherit_id:
+            type: "m2o"
+            expected_xml_id: "auth_signup.reset_password"
+          arch_db:
+            type: "value"
+            operator: "contains"
+            expected: "Your Username"
+
+  - name: "ssi_web_login - Set password email template uses login"
+    steps:
+      - step: "Get auth_signup.set_password_email template"
+        action: "ref"
+        xml_id: "auth_signup.set_password_email"
+        save_as: "template"
+      - step: "Assert body_html references object.login"
+        action: "assert"
+        target: "template"
+        asserts:
+          body_html:
+            type: "value"
+            operator: "contains"
+            expected: "${object.login}"
+
+  - name: "ssi_web_login - Signup account created email template uses login"
+    steps:
+      - step: "Get auth_signup.mail_template_user_signup_account_created template"
+        action: "ref"
+        xml_id: "auth_signup.mail_template_user_signup_account_created"
+        save_as: "template"
+      - step: "Assert body_html references object.login"
+        action: "assert"
+        target: "template"
+        asserts:
+          body_html:
+            type: "value"
+            operator: "contains"
+            expected: "${object.login}"

--- a/ssi_web_login/tests/test_ssi_web_login.py
+++ b/ssi_web_login/tests/test_ssi_web_login.py
@@ -9,5 +9,22 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestSsiWebLogin(YamlTransactionCase):
+    """Scenario tests for the ``ssi_web_login`` module."""
+
     def test_ssi_web_login(self):
+        """Run the install and auth signup override scenario."""
         self.run_yaml_scenario("test_data_ssi_web_login.yaml")
+
+    def test_mail_template_login_line_has_no_email(self):
+        """Assert mail template login lines omit ``${object.email}``.
+
+        Pure Python -- trigger P4 (L-05: the YAML DSL only offers the
+        ``contains`` operator; there is no ``not_contains`` nor regex
+        to assert that a substring is absent).
+        """
+        set_password_tmpl = self.env.ref("auth_signup.set_password_email")
+        signup_tmpl = self.env.ref(
+            "auth_signup.mail_template_user_signup_account_created"
+        )
+        self.assertNotIn("?login=${object.email}", set_password_tmpl.body_html)
+        self.assertNotIn("auth_login=${object.email}", signup_tmpl.body_html)

--- a/ssi_web_login/views/auth_signup_templates.xml
+++ b/ssi_web_login/views/auth_signup_templates.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). -->
+<odoo>
+    <template
+        id="ssi_web_login.auth_signup_fields"
+        inherit_id="auth_signup.fields"
+        name="SSI Web Login - Auth Signup Fields"
+        priority="99"
+    >
+        <xpath expr="//div[@class='form-group field-login']/label" position="replace">
+            <label for="login">Your Username</label>
+        </xpath>
+    </template>
+
+    <template
+        id="ssi_web_login.auth_signup_reset_password"
+        inherit_id="auth_signup.reset_password"
+        name="SSI Web Login - Auth Signup Reset Password"
+        priority="99"
+    >
+        <xpath expr="//div[@class='form-group field-login']/label" position="replace">
+            <label for="login" class="col-form-label">Your Username</label>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Mengganti label field login dari "Email" menjadi "Username" di seluruh
permukaan otentikasi web (login, signup, reset password) dan
mengoreksi mail template undangan/set-password `auth_signup` agar
memakai `res.users.login`, bukan email, sebagai kredensial login.

* Tambah `auth_signup` ke `depends`.
* View baru (`views/auth_signup_templates.xml`) berisi dua template
  inherit `priority="99"`: `auth_signup.fields` dan
  `auth_signup.reset_password`, label field login diganti "Your
  Username". XML ID lama `ssi_web_login.login` tidak diubah.
* Data baru (`data/auth_signup_mail_template_data.xml`) meng-override
  `body_html` dua `mail.template` core (`auth_signup.set_password_email`
  dan `auth_signup.mail_template_user_signup_account_created`, tanpa
  `noupdate`) agar tautan & teks memakai `${object.login}`.
* Unit test: skenario YAML positif untuk kedua view baru + kedua mail
  template, ditambah dua test Python murni (P7/L-19 `HttpCase` untuk
  halaman login & reset password, P4/L-05 assert `body_html` tidak
  memuat `${object.email}` pada baris login).
* README.rst diperbarui.

Closes #95