### PR TITLE
[UPD] ssi_web_widget_csv_table: default_mode option

### DIFF
--- a/.github/workflows/docstring-gate.yml
+++ b/.github/workflows/docstring-gate.yml
@@ -1,0 +1,284 @@
+# Gerbang docstring — memerahkan PR yang MENAMBAH class/method tanpa docstring.
+#
+# Aturannya milik skill `odoo-development`,
+# references/odoo-module-guidelines/10-docstring.md; berkas ini hanya menegakkannya
+# di CI. Salinan mekanis yang sama ada di `assets/verify-module.sh` skill itu — bila
+# salah satu diubah, ubah keduanya (kontrak validator §13 memakai kunci temuan yang
+# sama persis, jadi baris `.validator-exceptions` berlaku di dua-duanya).
+#
+# ── KENAPA WORKFLOW TERSENDIRI, BUKAN HOOK pre-commit ────────────────────────
+# `pre-commit run --all-files` di CI berjalan saat pohon kerja SAMA DENGAN HEAD, jadi
+# pembanding "apa yang baru" tidak ada dan hook seperti ini selalu hijau di sana —
+# hijau palsu. Workflow ini membandingkan HEAD PR dengan `merge-base` branch tujuan,
+# yang memang pembanding yang benar untuk "apa yang PR ini perkenalkan".
+#
+# ── KENAPA HANYA PELANGGARAN BARU ────────────────────────────────────────────
+# Korpus 14.0 memuat ~12.400 class/method tanpa docstring di 77 repo (sapuan 2026-08).
+# Memerahkan semuanya sekaligus tidak membuat satu docstring pun tertulis; ia hanya
+# membuat gerbang ini dimatikan. Yang ditahan karena itu HANYA simbol yang tak
+# berdocstring DAN belum ada di merge-base. Utang warisan diukur terpisah lewat
+# `audit-sweep.sh` (skill odoo-development-repo-ops), bukan di sini.
+#
+# Berkas ini identik di semua repo modul SSI dan semua seri Odoo — tanpa placeholder,
+# tanpa filter branch, supaya sync-config.sh bisa memverifikasinya byte-per-byte.
+name: docstring gate
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docstring-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docstring-gate:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Wajib: merge-base tidak bisa dihitung dari checkout dangkal.
+          fetch-depth: 0
+      - name: Gerbang docstring (hanya pelanggaran baru)
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --quiet origin "$BASE_REF"
+          MERGE_BASE="$(git merge-base "origin/$BASE_REF" HEAD)"
+          echo "Pembanding : origin/$BASE_REF @ $MERGE_BASE"
+          echo
+          python3 - "$MERGE_BASE" <<'PY'
+          import ast
+          import os
+          import subprocess
+          import sys
+
+          MERGE_BASE = sys.argv[1]
+          RULE = "setiap-class-method-punya-docstring"
+
+
+          def git(*args):
+              """Keluaran sebuah perintah git, atau None bila perintahnya gagal."""
+              proc = subprocess.run(
+                  ["git"] + list(args), capture_output=True, text=True
+              )
+              return proc.stdout if proc.returncode == 0 else None
+
+
+          # --- aturan pengecualian (CERMIN verify-module.sh; 10-docstring.md) ------
+          EXEMPT_EXACT = {"_insert_form_element", "_get_policy_field"}
+          ONCHANGE_PREFIX = ("onchange_", "_onchange_")
+
+
+          def real_body(fn):
+              """Statement body sebuah fungsi, tanpa baris docstring-nya."""
+              return fn.body[1:] if ast.get_docstring(fn) is not None else fn.body
+
+
+          def is_simple_onchange(fn):
+              """True bila onchange-nya Pattern A/B/C — reset/set field, titik.
+
+              decorator_list sengaja tidak ditelusuri: `@api.onchange("x")` sendiri
+              sebuah ``ast.Call``, dan menelusurinya membuat SETIAP onchange
+              terhitung tidak sederhana.
+              """
+              for st in real_body(fn):
+                  if not isinstance(st, (ast.Assign, ast.If)):
+                      return False
+                  for node in ast.walk(st):
+                      if isinstance(
+                          node,
+                          (
+                              ast.Call,
+                              ast.For,
+                              ast.While,
+                              ast.Try,
+                              ast.With,
+                              ast.Return,
+                              ast.Lambda,
+                          ),
+                      ):
+                          return False
+              return True
+
+
+          def doc_exempt(fn):
+              """True bila fungsi ini masuk pengecualian TERTUTUP 10-docstring.md."""
+              if fn.name in EXEMPT_EXACT:
+                  return True
+              if fn.name.startswith(ONCHANGE_PREFIX):
+                  return is_simple_onchange(fn)
+              if fn.name.startswith("_selection_"):
+                  return len(real_body(fn)) <= 1
+              return False
+
+
+          def missing_symbols(source):
+              """{nama simbol: lineno} untuk class/method tanpa docstring.
+
+              None bila sumbernya gagal di-parse — berkas yang sintaksnya rusak
+              ditagih flake8/pylint, dan menebak isinya di sini hanya menghasilkan
+              temuan palsu.
+              """
+              try:
+                  tree = ast.parse(source)
+              except SyntaxError:
+                  return None
+              found = {}
+              for node in ast.walk(tree):
+                  if not isinstance(
+                      node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+                  ):
+                      continue
+                  if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                      if doc_exempt(node):
+                          continue
+                  if ast.get_docstring(node) is None:
+                      found.setdefault(node.name, node.lineno)
+              return found
+
+
+          def module_root(path):
+              """Direktori modul Odoo terdekat di atas `path`, atau None."""
+              cur = os.path.dirname(path)
+              while cur:
+                  if os.path.isfile(os.path.join(cur, "__manifest__.py")):
+                      return cur
+                  parent = os.path.dirname(cur)
+                  if parent == cur:
+                      break
+                  cur = parent
+              return None
+
+
+          _baseline_cache = {}
+
+
+          def module_baseline(module):
+              """Nama simbol tanpa docstring di SELURUH modul, pada merge-base.
+
+              Pembandingnya sengaja setingkat MODUL, bukan per berkas. Standar SSI
+              mengizinkan struktur berkas ditata ulang selama XML ID & nama class utuh
+              (02-core-principles.md), dan perbandingan per berkas membaca pemindahan
+              class warisan sebagai "simbol baru" — lalu menuntut docstring untuk kode
+              yang tidak disentuh PR itu. Deteksi rename bawaan git tidak menutup
+              lubangnya: berkas yang dipindah SEKALIGUS diubah isinya jatuh di bawah
+              ambang kemiripan dan terbaca sebagai hapus + tambah.
+              """
+              if module not in _baseline_cache:
+                  names = set()
+                  listing = git("ls-tree", "-r", "--name-only", MERGE_BASE, "--", module)
+                  for path in (listing or "").splitlines():
+                      if not path.endswith(".py"):
+                          continue
+                      if os.path.basename(path) == "__init__.py":
+                          continue
+                      old_src = git("show", "%s:%s" % (MERGE_BASE, path))
+                      if not old_src:
+                          continue
+                      found = missing_symbols(old_src)
+                      if found:
+                          names.update(found)
+                  _baseline_cache[module] = names
+              return _baseline_cache[module]
+
+
+          _exc_cache = {}
+
+
+          def excepted(module, key):
+              """True bila kunci temuan ini tercakup <modul>/.validator-exceptions."""
+              if module not in _exc_cache:
+                  keys = set()
+                  path = os.path.join(module, ".validator-exceptions")
+                  if os.path.isfile(path):
+                      with open(path, encoding="utf-8") as fh:
+                          for raw in fh:
+                              line = raw.strip()
+                              if not line or line.startswith("#"):
+                                  continue
+                              head, sep, reason = line.partition(" -- ")
+                              if not sep or not reason.strip():
+                                  continue
+                              parts = head.split(None, 1)
+                              if len(parts) == 2 and parts[0] == "module":
+                                  keys.add(parts[1].strip())
+                  _exc_cache[module] = keys
+              return key in _exc_cache[module]
+
+
+          # --- berkas .py yang disentuh PR ini -------------------------------------
+          status = git("diff", "--name-status", "-M", MERGE_BASE, "HEAD")
+          if status is None:
+              sys.exit("ERROR: `git diff` terhadap merge-base gagal.")
+
+          pairs = []  # (path_baru, path_lama|None)
+          for line in status.splitlines():
+              cols = line.split("\t")
+              code = cols[0]
+              if code.startswith("D"):
+                  continue
+              if code.startswith("R") and len(cols) == 3:
+                  pairs.append((cols[2], cols[1]))
+              elif len(cols) >= 2:
+                  pairs.append((cols[1], cols[1]))
+
+          findings = []
+          checked = 0
+          for new_path, old_path in pairs:
+              if not new_path.endswith(".py"):
+                  continue
+              if os.path.basename(new_path) == "__init__.py":
+                  continue
+              # setup/ hanya berisi symlink hasil setuptools-odoo.
+              if new_path.startswith("setup/"):
+                  continue
+              if not os.path.isfile(new_path):
+                  continue
+              with open(new_path, encoding="utf-8") as fh:
+                  new_missing = missing_symbols(fh.read())
+              if new_missing is None:
+                  continue
+              checked += 1
+              module = module_root(new_path)
+              if module:
+                  baseline = module_baseline(module)
+              else:
+                  # Di luar modul Odoo (skrip lepas): tak ada modul untuk dibandingkan,
+                  # jadi pembandingnya kembali ke berkas itu sendiri di merge-base.
+                  old_src = git("show", "%s:%s" % (MERGE_BASE, old_path)) if old_path else None
+                  baseline = set(missing_symbols(old_src) or {}) if old_src else set()
+              for name, lineno in sorted(new_missing.items(), key=lambda kv: kv[1]):
+                  if name in baseline:
+                      continue  # utang warisan — diukur audit-sweep.sh, bukan di sini
+                  rel = os.path.relpath(new_path, module) if module else new_path
+                  if module and excepted(module, "%s|%s %s" % (RULE, rel, name)):
+                      print("  ⊘ %s:%d %s  [.validator-exceptions]" % (new_path, lineno, name))
+                      continue
+                  findings.append((new_path, lineno, name))
+
+          print("Berkas .py diperiksa: %d" % checked)
+          if not findings:
+              print("")
+              print("LOLOS: tidak ada class/method baru tanpa docstring.")
+              sys.exit(0)
+
+          print("")
+          print("GAGAL: %d class/method BARU tanpa docstring." % len(findings))
+          print("")
+          for path, lineno, name in findings:
+              print("  ✗ %s:%d %s" % (path, lineno, name))
+          print("")
+          print("Aturannya: skill odoo-development,")
+          print("  references/odoo-module-guidelines/10-docstring.md")
+          print("Reproduksi & perbaiki di lokal:")
+          print("  assets/vs-head.sh verify-module.sh <path-modul>")
+          print("")
+          print("Pengecualiannya TERTUTUP. Bila sebuah temuan memang tidak boleh")
+          print("diperbaiki, daftarkan di <modul>/.validator-exceptions berikut")
+          print("alasannya (kontrak validator §13) — jangan matikan gerbang ini.")
+          sys.exit(1)
+          PY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,17 @@ jobs:
         env:
           PIP_INDEX_URL: https://pypi.org/simple
           PIP_EXTRA_INDEX_URL: https://${{ secrets.SSI_PYPI_USER }}:${{ secrets.SSI_PYPI_PASSWORD }}@osmium.simetri-sinergi.biz.id/simple/
+      - name: Pre-install chart of accounts
+        # Memasang l10n_generic_coa ke DB test SEBELUM `oca_init_test_database`.
+        # Saat modul ini berstatus `to install`, pemeriksaan `to_install_l10n`
+        # (account/__init__.py) bernilai benar sehingga `_auto_install_l10n`
+        # berhenti tanpa memasang l10n_us; chart of accounts juga sudah termuat
+        # sebelum demo modul SSI lahir, sehingga `chart_template._load()` tidak
+        # pernah menghapus account.journal/account.account yang dirujuk demo.
+        # Demo TIDAK dimatikan: tour dan skenario uji bergantung padanya.
+        run: |
+          oca_wait_for_postgres
+          odoo -d "$PGDATABASE" -i l10n_generic_coa --http-interface=127.0.0.1 --stop-after-init
       - name: Check licenses
         run: manifestoo -d . check-licenses
         continue-on-error: true

--- a/ssi_web_widget_csv_table/README.rst
+++ b/ssi_web_widget_csv_table/README.rst
@@ -29,7 +29,17 @@ The widget will:
 
 * **Readonly mode**: Parse the CSV text and display it as a styled table with
   row numbers, sticky headers, numeric alignment, and row count info.
-* **Edit mode**: Show a standard textarea for CSV input/editing.
+* **Edit mode**: Show a "Text" / "Table" toggle. "Text" is a standard
+  textarea for raw CSV input; "Table" renders an editable grid (per-cell
+  text inputs, checkboxes for ``TRUE``/``FALSE`` values, and pagination).
+  Both modes stay in sync and edits in either one are saved together.
+
+By default, edit mode opens in "Text". Pass ``default_mode: "table"`` in
+``options`` to open in "Table" instead:
+
+.. code-block:: xml
+
+    <field name="sampling_data" widget="csv_table" options="{'default_mode': 'table'}" />
 
 Bug Tracker
 ===========

--- a/ssi_web_widget_csv_table/static/src/js/ssi_web_widget_csv_table.js
+++ b/ssi_web_widget_csv_table/static/src/js/ssi_web_widget_csv_table.js
@@ -397,7 +397,8 @@ odoo.define("ssi_web_widget_csv_table.csv_table", function (require) {
         init: function () {
             this._super.apply(this, arguments);
             this._hasHeader = true;
-            this._tableEditMode = false;
+            this._tableEditMode =
+                (this.nodeOptions && this.nodeOptions.default_mode) === "table";
             this._currentPage = 0;
             this._pageSize = 50;
             this._parsedRows = null;


### PR DESCRIPTION
## Summary
- Add `options={'default_mode': 'table'}` to open the csv_table widget's edit mode directly in Table view instead of Text (default stays Text when unset, so existing usages are unaffected).
- Sync CI config with the 14.0 standard (missing pre-install chart-of-accounts step in test.yml, missing docstring-gate.yml).

## Test plan
- [x] pre-commit run --all-files passes
- [x] Manually verified in odoo14-audit-tools devel: widget opens in Table mode when the option is set, Text mode unchanged for fields without it